### PR TITLE
fix: use ancestor-path tracking in stringifyUnknown to avoid false circular detection

### DIFF
--- a/lib/utils/__tests__/types.test.ts
+++ b/lib/utils/__tests__/types.test.ts
@@ -48,6 +48,14 @@ describe("stringifyUnknown", () => {
     expect(result).toContain('"a":1');
   });
 
+  it("does not mark shared (non-circular) references as circular", () => {
+    // Diamond pattern: both a and b point to the same object but there is no cycle.
+    // The old WeakSet approach incorrectly returned "[Circular]" for the second reference.
+    const shared = { x: 1 };
+    const obj = { a: shared, b: shared };
+    expect(stringifyUnknown(obj)).toBe('{"a":{"x":1},"b":{"x":1}}');
+  });
+
   it("falls back to String() for BigInt (non-serializable by JSON.stringify)", () => {
     // BigInt causes JSON.stringify to throw — the try-catch must handle it
     expect(stringifyUnknown(BigInt(42))).toBe("42");

--- a/lib/utils/__tests__/types.test.ts
+++ b/lib/utils/__tests__/types.test.ts
@@ -56,6 +56,48 @@ describe("stringifyUnknown", () => {
     expect(stringifyUnknown(obj)).toBe('{"a":{"x":1},"b":{"x":1}}');
   });
 
+  it("does not mark shared references at multiple depths as circular", () => {
+    // shared is nested inside two sibling wrapper objects — still not a cycle.
+    const shared = { x: 1 };
+    const obj = { p: { shared }, q: { shared } };
+    const result = stringifyUnknown(obj);
+    expect(result).toBe('{"p":{"shared":{"x":1}},"q":{"shared":{"x":1}}}');
+    expect(result).not.toContain("[Circular]");
+  });
+
+  it("does not mark shared references inside arrays as circular", () => {
+    const shared = { x: 1 };
+    const arr = [shared, shared, shared];
+    expect(stringifyUnknown(arr)).toBe('[{"x":1},{"x":1},{"x":1}]');
+  });
+
+  it("detects circular references at depth, not just at root", () => {
+    const inner: Record<string, unknown> = { y: 2 };
+    inner["self"] = inner;
+    const obj = { outer: 1, inner };
+    const result = stringifyUnknown(obj);
+    expect(result).toContain("[Circular]");
+    expect(result).toContain('"y":2');
+    expect(result).toContain('"outer":1');
+  });
+
+  it("handles null values in objects without throwing", () => {
+    expect(stringifyUnknown({ a: null, b: 1 })).toBe('{"a":null,"b":1}');
+  });
+
+  it("handles shared object that is itself circular", () => {
+    // circ is both shared (referenced from a and b) and circular (self-referential).
+    // Each reference should detect the cycle independently.
+    const circ: Record<string, unknown> = {};
+    circ["self"] = circ;
+    const obj = { a: circ, b: circ };
+    const result = stringifyUnknown(obj);
+    expect(result).toContain('"self":"[Circular]"');
+    // Both a and b should be serialized (shared ref handled), each with their own [Circular]
+    expect(result).toContain('"a":{');
+    expect(result).toContain('"b":{');
+  });
+
   it("falls back to String() for BigInt (non-serializable by JSON.stringify)", () => {
     // BigInt causes JSON.stringify to throw — the try-catch must handle it
     expect(stringifyUnknown(BigInt(42))).toBe("42");

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -14,17 +14,34 @@ export function stringifyUnknown(value: unknown): string {
   // Track only the current ancestor path (not all visited objects) to correctly
   // distinguish true circular references from shared/diamond references.
   // A shared object { a: x, b: x } is safe — only flag x if it appears in its
-  // own ancestor chain. Uses JSON.stringify's `this` context to trim the stack
-  // as traversal moves between siblings.
+  // own ancestor chain.
+  //
+  // Implementation note: uses JSON.stringify's `this` context in the replacer
+  // to identify the current parent object and trim the ancestor stack when
+  // traversal moves to a sibling subtree. This behaviour — `this` referring to
+  // the containing object — is consistent across V8, SpiderMonkey, and JSC and
+  // matches the intent of the spec (ECMA-262 §25.5.2.1), though the spec does
+  // not explicitly mandate it for replacer functions.
+  //
+  // `ancestors` is a WeakSet (not Set) so serialized objects are not retained
+  // beyond the lifetime of the replacer call; `stack` is a plain array because
+  // WeakSet does not support indexed access needed for the trim loop.
+  //
   // Wrapped in try-catch for non-serializable values like BigInt.
   try {
-    const ancestors = new Set<object>();
+    const ancestors = new WeakSet<object>();
     const stack: object[] = [];
     return (
       JSON.stringify(value, function (this: unknown, _key, val) {
         if (typeof val === "object" && val !== null) {
-          // Trim the stack back to the current parent so siblings don't
-          // inherit each other's children as ancestors.
+          // On the first call `this` is JSON.stringify's synthetic {"":rootValue}
+          // wrapper — the empty stack guard means no trimming occurs and the root
+          // object is simply pushed, which is correct.
+          //
+          // On subsequent calls, trim the stack back to the current parent (`this`)
+          // before checking for cycles. This removes children of previously visited
+          // siblings from the ancestor set so that shared references — objects
+          // reachable via multiple paths — are not incorrectly flagged as circular.
           while (stack.length > 0 && stack[stack.length - 1] !== this) {
             const top = stack.pop();
             if (top !== undefined) ancestors.delete(top);

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -26,7 +26,8 @@ export function stringifyUnknown(value: unknown): string {
           // Trim the stack back to the current parent so siblings don't
           // inherit each other's children as ancestors.
           while (stack.length > 0 && stack[stack.length - 1] !== this) {
-            ancestors.delete(stack.pop()!);
+            const top = stack.pop();
+            if (top !== undefined) ancestors.delete(top);
           }
           if (ancestors.has(val)) return "[Circular]";
           ancestors.add(val);

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -11,16 +11,26 @@ export function stringifyUnknown(value: unknown): string {
     return value;
   }
 
-  // Use a WeakSet replacer to handle circular references, and wrap in try-catch
-  // to guard against non-serializable values like BigInt (which JSON.stringify
-  // throws for rather than returning null/undefined — so ?? cannot catch it).
+  // Track only the current ancestor path (not all visited objects) to correctly
+  // distinguish true circular references from shared/diamond references.
+  // A shared object { a: x, b: x } is safe — only flag x if it appears in its
+  // own ancestor chain. Uses JSON.stringify's `this` context to trim the stack
+  // as traversal moves between siblings.
+  // Wrapped in try-catch for non-serializable values like BigInt.
   try {
-    const seen = new WeakSet();
+    const ancestors = new Set<object>();
+    const stack: object[] = [];
     return (
-      JSON.stringify(value, (_key, val) => {
+      JSON.stringify(value, function (this: unknown, _key, val) {
         if (typeof val === "object" && val !== null) {
-          if (seen.has(val)) return "[Circular]";
-          seen.add(val);
+          // Trim the stack back to the current parent so siblings don't
+          // inherit each other's children as ancestors.
+          while (stack.length > 0 && stack[stack.length - 1] !== this) {
+            ancestors.delete(stack.pop()!);
+          }
+          if (ancestors.has(val)) return "[Circular]";
+          ancestors.add(val);
+          stack.push(val);
         }
         return val as unknown;
       }) ?? String(value)


### PR DESCRIPTION
## Summary

- Replaces the global `WeakSet` in `stringifyUnknown` with ancestor-path tracking using `JSON.stringify`'s `this` context
- The old approach marked any repeated object as `"[Circular]"`, including legitimate shared references (diamond patterns like `{ a: shared, b: shared }`)
- The new approach only flags an object as circular if it appears in its own ancestor chain
- `ancestors` uses `WeakSet<object>` (GC-friendly); `stack` stays a plain array since WeakSet has no indexed access
- Documents the `this`-context assumption (consistent across V8/SpiderMonkey/JSC, matches ECMA-262 §25.5.2.1 intent)

## Test plan

- [x] `stringifyUnknown({ a: shared, b: shared })` correctly serializes both references (regression test added)
- [x] Shared refs at multiple depths do not produce false `[Circular]`
- [x] Shared refs inside arrays do not produce false `[Circular]`
- [x] True circular references still produce `"[Circular]"` (existing test passes)
- [x] Circular reference at depth (not root) detected correctly
- [x] Null values in objects handled without throwing
- [x] Shared object that is itself circular: both refs serialized, cycle detected per-ref
- [x] All 93 tests pass
- [x] Typecheck clean
- [x] ESLint clean

Closes finding from PR #45 review: [P2] Shared-object references treated as circular.