### PR TITLE
Issue #26: Implement API routes for scan, brief, deep-dive, and cron

### DIFF
--- a/app/api/_lib/auth.ts
+++ b/app/api/_lib/auth.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from "next/server";
+
+function readBearerToken(request: NextRequest): string | null {
+  const value = request.headers.get("authorization");
+  if (!value) return null;
+  const [scheme, token] = value.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+}
+
+export function hasValidInternalApiKey(request: NextRequest): boolean {
+  const expected = process.env.INTERNAL_API_KEY;
+  if (!expected) return false;
+  const header = request.headers.get("x-internal-api-key");
+  const bearer = readBearerToken(request);
+  return header === expected || bearer === expected;
+}
+
+export function isSameOriginRequest(request: NextRequest): boolean {
+  const requestOrigin = request.nextUrl.origin;
+  const origin = request.headers.get("origin");
+  if (origin) return origin === requestOrigin;
+
+  const referer = request.headers.get("referer");
+  if (!referer) return false;
+
+  try {
+    return new URL(referer).origin === requestOrigin;
+  } catch {
+    return false;
+  }
+}
+

--- a/app/api/brief/route.ts
+++ b/app/api/brief/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { hasValidInternalApiKey } from "@/app/api/_lib/auth";
 import { generateCompetitorBrief } from "@/lib/brief";
 
 type BriefRequest = {
@@ -7,18 +8,20 @@ type BriefRequest = {
 };
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as BriefRequest;
-
-  if (!body.competitorId) {
-    return NextResponse.json({ error: "competitorId is required" }, { status: 400 });
+  if (!hasValidInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {
+    const body = (await request.json()) as BriefRequest;
+    if (!body.competitorId) {
+      return NextResponse.json({ error: "competitorId is required" }, { status: 400 });
+    }
     const brief = await generateCompetitorBrief(body.competitorId, true);
     return NextResponse.json({ brief });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to generate brief";
-    const status = message === "Competitor not found" ? 404 : 500;
+    const status = message === "Competitor not found" ? 404 : message.toLowerCase().includes("json") ? 400 : 500;
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/app/api/brief/route.ts
+++ b/app/api/brief/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { generateCompetitorBrief } from "@/lib/brief";
+
+type BriefRequest = {
+  competitorId?: string;
+};
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as BriefRequest;
+
+  if (!body.competitorId) {
+    return NextResponse.json({ error: "competitorId is required" }, { status: 400 });
+  }
+
+  try {
+    const brief = await generateCompetitorBrief(body.competitorId, true);
+    return NextResponse.json({ brief });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to generate brief";
+    const status = message === "Competitor not found" ? 404 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/competitors/route.ts
+++ b/app/api/competitors/route.ts
@@ -1,9 +1,18 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
+import { hasValidInternalApiKey, isSameOriginRequest } from "@/app/api/_lib/auth";
 import { listCompetitors } from "@/lib/db/competitors";
 
-export async function GET() {
-  const competitors = await listCompetitors({ includePages: true });
-  return NextResponse.json({ competitors });
-}
+export async function GET(request: NextRequest) {
+  if (!hasValidInternalApiKey(request) && !isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
+  try {
+    const competitors = await listCompetitors({ includePages: true });
+    return NextResponse.json({ competitors });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load competitors";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/competitors/route.ts
+++ b/app/api/competitors/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { listCompetitors } from "@/lib/db/competitors";
+
+export async function GET() {
+  const competitors = await listCompetitors({ includePages: true });
+  return NextResponse.json({ competitors });
+}
+

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -12,6 +12,54 @@ function isAuthorized(request: NextRequest): boolean {
   return headerSecret === secret || bearer === `Bearer ${secret}`;
 }
 
+const DEFAULT_CONCURRENCY = 3;
+
+async function processCompetitor(
+  competitor: {
+    id: string;
+    pages: Array<{
+      id: string;
+      label: string;
+      url: string;
+      type: string;
+      geoTarget: string | null;
+    }>;
+  },
+  briefNocache: boolean
+) {
+  const item = {
+    competitorId: competitor.id,
+    pagesScanned: 0,
+    briefGenerated: false,
+    errors: [] as string[]
+  };
+
+  for (const page of competitor.pages) {
+    try {
+      await scanPage({
+        competitorId: competitor.id,
+        pageId: page.id,
+        label: page.label,
+        url: page.url,
+        type: page.type,
+        geoTarget: page.geoTarget
+      });
+      item.pagesScanned += 1;
+    } catch (error) {
+      item.errors.push(`page ${page.id}: ${error instanceof Error ? error.message : "scan failed"}`);
+    }
+  }
+
+  try {
+    await generateCompetitorBrief(competitor.id, briefNocache);
+    item.briefGenerated = true;
+  } catch (error) {
+    item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);
+  }
+
+  return item;
+}
+
 export async function POST(request: NextRequest) {
   if (!isAuthorized(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -21,47 +69,15 @@ export async function POST(request: NextRequest) {
     include: { pages: true }
   });
 
-  const summary: Array<{
-    competitorId: string;
-    pagesScanned: number;
-    briefGenerated: boolean;
-    errors: string[];
-  }> = [];
+  const briefNocache = process.env.CRON_BRIEF_NOCACHE === "true";
+  const concurrency = Number(process.env.CRON_CONCURRENCY ?? DEFAULT_CONCURRENCY);
+  const safeConcurrency = Number.isFinite(concurrency) ? Math.max(1, Math.min(10, concurrency)) : DEFAULT_CONCURRENCY;
 
-  for (const competitor of competitors) {
-    const item = {
-      competitorId: competitor.id,
-      pagesScanned: 0,
-      briefGenerated: false,
-      errors: [] as string[]
-    };
-
-    for (const page of competitor.pages) {
-      try {
-        await scanPage({
-          competitorId: competitor.id,
-          pageId: page.id,
-          label: page.label,
-          url: page.url,
-          type: page.type,
-          geoTarget: page.geoTarget
-        });
-        item.pagesScanned += 1;
-      } catch (error) {
-        item.errors.push(
-          `page ${page.id}: ${error instanceof Error ? error.message : "scan failed"}`
-        );
-      }
-    }
-
-    try {
-      await generateCompetitorBrief(competitor.id, true);
-      item.briefGenerated = true;
-    } catch (error) {
-      item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);
-    }
-
-    summary.push(item);
+  const summary: Awaited<ReturnType<typeof processCompetitor>>[] = [];
+  for (let index = 0; index < competitors.length; index += safeConcurrency) {
+    const chunk = competitors.slice(index, index + safeConcurrency);
+    const results = await Promise.all(chunk.map((competitor) => processCompetitor(competitor, briefNocache)));
+    summary.push(...results);
   }
 
   return NextResponse.json({

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -6,7 +6,10 @@ import { scanPage } from "@/lib/scanner";
 
 function isAuthorized(request: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;
-  if (!secret) return false;
+  if (!secret) {
+    console.error("[api/cron] CRON_SECRET is not configured.");
+    return false;
+  }
   const headerSecret = request.headers.get("x-cron-secret");
   const bearer = request.headers.get("authorization");
   return headerSecret === secret || bearer === `Bearer ${secret}`;

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { generateCompetitorBrief } from "@/lib/brief";
+import { prisma } from "@/lib/db/client";
+import { scanPage } from "@/lib/scanner";
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const headerSecret = request.headers.get("x-cron-secret");
+  const bearer = request.headers.get("authorization");
+  return headerSecret === secret || bearer === `Bearer ${secret}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const competitors = await prisma.competitor.findMany({
+    include: { pages: true }
+  });
+
+  const summary: Array<{
+    competitorId: string;
+    pagesScanned: number;
+    briefGenerated: boolean;
+    errors: string[];
+  }> = [];
+
+  for (const competitor of competitors) {
+    const item = {
+      competitorId: competitor.id,
+      pagesScanned: 0,
+      briefGenerated: false,
+      errors: [] as string[]
+    };
+
+    for (const page of competitor.pages) {
+      try {
+        await scanPage({
+          competitorId: competitor.id,
+          pageId: page.id,
+          label: page.label,
+          url: page.url,
+          type: page.type,
+          geoTarget: page.geoTarget
+        });
+        item.pagesScanned += 1;
+      } catch (error) {
+        item.errors.push(
+          `page ${page.id}: ${error instanceof Error ? error.message : "scan failed"}`
+        );
+      }
+    }
+
+    try {
+      await generateCompetitorBrief(competitor.id, true);
+      item.briefGenerated = true;
+    } catch (error) {
+      item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);
+    }
+
+    summary.push(item);
+  }
+
+  return NextResponse.json({
+    competitors: competitors.length,
+    summary
+  });
+}

--- a/app/api/deep-dive/route.ts
+++ b/app/api/deep-dive/route.ts
@@ -1,0 +1,102 @@
+import type { NextRequest } from "next/server";
+
+import { prisma } from "@/lib/db/client";
+import { runResearch } from "@/lib/tabstack/research";
+
+type DeepDiveRequest = {
+  competitorId?: string;
+  mode?: "fast" | "balanced";
+};
+
+const encoder = new TextEncoder();
+
+function sse(event: string, data: unknown): Uint8Array {
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function buildResearchQuery(name: string): string {
+  return `Research ${name} as a competitive threat. Cover:
+- Developer sentiment across forums, GitHub issues, and social
+- Strategic moves and product changes in the last 6 months
+- Actual developer experience vs. marketing claims
+- Hiring signals and org changes
+- Funding, acquisition, or partnership signals
+Provide inline citations for every claim.`;
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as DeepDiveRequest;
+  if (!body.competitorId) {
+    return new Response(JSON.stringify({ error: "competitorId is required" }), {
+      status: 400,
+      headers: { "content-type": "application/json" }
+    });
+  }
+
+  const mode = body.mode ?? "balanced";
+  const competitor = await prisma.competitor.findUnique({ where: { id: body.competitorId } });
+  if (!competitor) {
+    return new Response(JSON.stringify({ error: "Competitor not found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" }
+    });
+  }
+
+  const stream = new ReadableStream({
+    start: async (controller) => {
+      try {
+        controller.enqueue(sse("research:started", { competitorId: competitor.id, mode }));
+        const query = buildResearchQuery(competitor.name);
+
+        const result = await runResearch({
+          competitorId: competitor.id,
+          query,
+          mode,
+          nocache: true
+        });
+
+        for (const event of result.events) {
+          controller.enqueue(
+            sse("research:progress", {
+              event: event.event ?? "unknown",
+              data: event.data
+            })
+          );
+        }
+
+        await prisma.deepDive.create({
+          data: {
+            competitorId: competitor.id,
+            mode,
+            query,
+            result: result.result as never,
+            citations: result.citations as never
+          }
+        });
+
+        controller.enqueue(
+          sse("research:complete", {
+            result: result.result,
+            citations: result.citations
+          })
+        );
+      } catch (error) {
+        controller.enqueue(
+          sse("research:error", {
+            error: error instanceof Error ? error.message : "Deep dive failed"
+          })
+        );
+      } finally {
+        controller.close();
+      }
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive"
+    }
+  });
+}

--- a/app/api/deep-dive/route.ts
+++ b/app/api/deep-dive/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/db/client";
 import { runResearch } from "@/lib/tabstack/research";
@@ -22,6 +23,15 @@ function buildResearchQuery(name: string): string {
 - Hiring signals and org changes
 - Funding, acquisition, or partnership signals
 Provide inline citations for every claim.`;
+}
+
+function toJsonValue(value: unknown): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
+  if (value === null || value === undefined) return Prisma.JsonNull;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
+    return value as Prisma.InputJsonValue;
+  }
+  return String(value);
 }
 
 export async function POST(request: NextRequest) {
@@ -69,8 +79,8 @@ export async function POST(request: NextRequest) {
             competitorId: competitor.id,
             mode,
             query,
-            result: result.result as never,
-            citations: result.citations as never
+            result: toJsonValue(result.result),
+            citations: toJsonValue(result.citations)
           }
         });
 

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { hasValidInternalApiKey, isSameOriginRequest } from "@/app/api/_lib/auth";
 import { prisma } from "@/lib/db/client";
 
 type NotificationsQuery = {
@@ -8,22 +9,31 @@ type NotificationsQuery = {
 };
 
 export async function GET(request: NextRequest) {
-  const query = Object.fromEntries(request.nextUrl.searchParams.entries()) as NotificationsQuery;
-  const limit = Number(query.limit ?? "50");
+  if (!hasValidInternalApiKey(request) && !isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
-  const notifications = await prisma.notification.findMany({
-    where: {
-      competitorId: query.competitorId
-    },
-    include: {
-      competitor: true,
-      scan: {
-        include: { page: true }
-      }
-    },
-    orderBy: { sentAt: "desc" },
-    take: Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 50
-  });
+  try {
+    const query = Object.fromEntries(request.nextUrl.searchParams.entries()) as NotificationsQuery;
+    const limit = Number(query.limit ?? "50");
 
-  return NextResponse.json({ notifications });
+    const notifications = await prisma.notification.findMany({
+      where: {
+        competitorId: query.competitorId
+      },
+      include: {
+        competitor: true,
+        scan: {
+          include: { page: true }
+        }
+      },
+      orderBy: { sentAt: "desc" },
+      take: Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 50
+    });
+
+    return NextResponse.json({ notifications });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load notifications";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { prisma } from "@/lib/db/client";
+
+type NotificationsQuery = {
+  competitorId?: string;
+  limit?: string;
+};
+
+export async function GET(request: NextRequest) {
+  const query = Object.fromEntries(request.nextUrl.searchParams.entries()) as NotificationsQuery;
+  const limit = Number(query.limit ?? "50");
+
+  const notifications = await prisma.notification.findMany({
+    where: {
+      competitorId: query.competitorId
+    },
+    include: {
+      competitor: true,
+      scan: {
+        include: { page: true }
+      }
+    },
+    orderBy: { sentAt: "desc" },
+    take: Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 50
+  });
+
+  return NextResponse.json({ notifications });
+}

--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { generateCompetitorBrief } from "@/lib/brief";
+import { prisma } from "@/lib/db/client";
+import { scanPage } from "@/lib/scanner";
+
+type ScanRequest = {
+  competitorId?: string;
+  pageId?: string;
+  runBrief?: boolean;
+};
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json()) as ScanRequest;
+
+  if (!body.competitorId && !body.pageId) {
+    return NextResponse.json({ error: "competitorId or pageId is required" }, { status: 400 });
+  }
+
+  if (body.pageId) {
+    const page = await prisma.competitorPage.findUnique({
+      where: { id: body.pageId }
+    });
+    if (!page) {
+      return NextResponse.json({ error: "Page not found" }, { status: 404 });
+    }
+
+    const result = await scanPage({
+      competitorId: page.competitorId,
+      pageId: page.id,
+      label: page.label,
+      url: page.url,
+      type: page.type,
+      geoTarget: page.geoTarget
+    });
+
+    return NextResponse.json({ results: [result] });
+  }
+
+  const competitor = await prisma.competitor.findUnique({
+    where: { id: body.competitorId },
+    include: { pages: true }
+  });
+
+  if (!competitor) {
+    return NextResponse.json({ error: "Competitor not found" }, { status: 404 });
+  }
+
+  const results = [];
+  for (const page of competitor.pages) {
+    const result = await scanPage({
+      competitorId: competitor.id,
+      pageId: page.id,
+      label: page.label,
+      url: page.url,
+      type: page.type,
+      geoTarget: page.geoTarget
+    });
+    results.push(result);
+  }
+
+  if (body.runBrief ?? true) {
+    await generateCompetitorBrief(competitor.id, true);
+  }
+
+  return NextResponse.json({ results });
+}

--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -8,6 +8,7 @@ type ScanRequest = {
   competitorId?: string;
   pageId?: string;
   runBrief?: boolean;
+  briefNocache?: boolean;
 };
 
 export async function POST(request: NextRequest) {
@@ -59,8 +60,13 @@ export async function POST(request: NextRequest) {
     results.push(result);
   }
 
-  if (body.runBrief ?? true) {
-    await generateCompetitorBrief(competitor.id, true);
+  if (body.runBrief === true) {
+    try {
+      await generateCompetitorBrief(competitor.id, body.briefNocache ?? false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Brief generation failed";
+      return NextResponse.json({ results, briefError: message }, { status: 409 });
+    }
   }
 
   return NextResponse.json({ results });

--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { generateCompetitorBrief } from "@/lib/brief";
+import { hasValidInternalApiKey } from "@/app/api/_lib/auth";
 import { prisma } from "@/lib/db/client";
 import { scanPage } from "@/lib/scanner";
 
@@ -12,62 +13,72 @@ type ScanRequest = {
 };
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as ScanRequest;
-
-  if (!body.competitorId && !body.pageId) {
-    return NextResponse.json({ error: "competitorId or pageId is required" }, { status: 400 });
+  if (!hasValidInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (body.pageId) {
-    const page = await prisma.competitorPage.findUnique({
-      where: { id: body.pageId }
-    });
-    if (!page) {
-      return NextResponse.json({ error: "Page not found" }, { status: 404 });
+  try {
+    const body = (await request.json()) as ScanRequest;
+
+    if (!body.competitorId && !body.pageId) {
+      return NextResponse.json({ error: "competitorId or pageId is required" }, { status: 400 });
     }
 
-    const result = await scanPage({
-      competitorId: page.competitorId,
-      pageId: page.id,
-      label: page.label,
-      url: page.url,
-      type: page.type,
-      geoTarget: page.geoTarget
-    });
+    if (body.pageId) {
+      const page = await prisma.competitorPage.findUnique({
+        where: { id: body.pageId }
+      });
+      if (!page) {
+        return NextResponse.json({ error: "Page not found" }, { status: 404 });
+      }
 
-    return NextResponse.json({ results: [result] });
-  }
+      const result = await scanPage({
+        competitorId: page.competitorId,
+        pageId: page.id,
+        label: page.label,
+        url: page.url,
+        type: page.type,
+        geoTarget: page.geoTarget
+      });
 
-  const competitor = await prisma.competitor.findUnique({
-    where: { id: body.competitorId },
-    include: { pages: true }
-  });
-
-  if (!competitor) {
-    return NextResponse.json({ error: "Competitor not found" }, { status: 404 });
-  }
-
-  const results = [];
-  for (const page of competitor.pages) {
-    const result = await scanPage({
-      competitorId: competitor.id,
-      pageId: page.id,
-      label: page.label,
-      url: page.url,
-      type: page.type,
-      geoTarget: page.geoTarget
-    });
-    results.push(result);
-  }
-
-  if (body.runBrief === true) {
-    try {
-      await generateCompetitorBrief(competitor.id, body.briefNocache ?? false);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Brief generation failed";
-      return NextResponse.json({ results, briefError: message }, { status: 409 });
+      return NextResponse.json({ results: [result] });
     }
-  }
 
-  return NextResponse.json({ results });
+    const competitor = await prisma.competitor.findUnique({
+      where: { id: body.competitorId },
+      include: { pages: true }
+    });
+
+    if (!competitor) {
+      return NextResponse.json({ error: "Competitor not found" }, { status: 404 });
+    }
+
+    const results = await Promise.all(
+      competitor.pages.map((page) =>
+        scanPage({
+          competitorId: competitor.id,
+          pageId: page.id,
+          label: page.label,
+          url: page.url,
+          type: page.type,
+          geoTarget: page.geoTarget
+        })
+      )
+    );
+
+    if (body.runBrief === true) {
+      try {
+        await generateCompetitorBrief(competitor.id, body.briefNocache ?? false);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Brief generation failed";
+        return NextResponse.json({ results, briefError: message }, { status: 409 });
+      }
+    }
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Scan request failed";
+    const status = message.toLowerCase().includes("json") ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -1,0 +1,107 @@
+/**
+ * Intelligence brief generation.
+ *
+ * What it does:
+ * - Collects latest scan outputs for a competitor.
+ * - Sends consolidated context to Tabstack /generate for structured brief output.
+ * - Persists intelligence_brief and threat_level on competitor records.
+ *
+ * Cost tier:
+ * - Medium. Uses /generate once per competitor scan cycle.
+ *
+ * When to use vs alternatives:
+ * - Use after scan cycles complete.
+ * - Do not call /generate per-page for this use case.
+ *
+ * Key parameters:
+ * - competitorId: target competitor
+ * - nocache: defaults to true
+ *
+ * Fallback behavior:
+ * - No internal fallback. Caller handles errors.
+ */
+
+import { prisma } from "@/lib/db/client";
+import { generateBrief } from "@/lib/tabstack/generate";
+import { isPlainObject, stringifyUnknown } from "@/lib/utils/types";
+import { Prisma } from "@prisma/client";
+
+function latestScanContext(scans: Array<{ pageType: string; pageLabel: string; result: unknown }>): string {
+  return JSON.stringify(
+    scans.map((scan) => ({
+      page_type: scan.pageType,
+      page_label: scan.pageLabel,
+      result: scan.result
+    }))
+  );
+}
+
+function parseThreatLevel(value: unknown): string | null {
+  if (!isPlainObject(value)) return null;
+  const level = value["threat_level"];
+  if (typeof level !== "string") return null;
+  if (level !== "High" && level !== "Medium" && level !== "Low") return null;
+  return level;
+}
+
+function extractBriefPayload(value: unknown): unknown {
+  if (!isPlainObject(value)) return value;
+  if ("data" in value) return value["data"];
+  return value;
+}
+
+function toJsonValue(value: unknown): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
+  if (value === null || value === undefined) return Prisma.JsonNull;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value) || isPlainObject(value)) return value as Prisma.InputJsonValue;
+  return stringifyUnknown(value);
+}
+
+export async function generateCompetitorBrief(competitorId: string, nocache = true) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { id: competitorId },
+    include: { pages: true }
+  });
+
+  if (!competitor) {
+    throw new Error("Competitor not found");
+  }
+
+  const scans = await prisma.scan.findMany({
+    where: { page: { competitorId } },
+    include: { page: true },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  const latestByPage = new Map<string, { pageType: string; pageLabel: string; result: unknown }>();
+  for (const scan of scans) {
+    if (latestByPage.has(scan.pageId)) continue;
+    latestByPage.set(scan.pageId, {
+      pageType: scan.page.type,
+      pageLabel: scan.page.label,
+      result: scan.markdownResult ?? scan.rawResult
+    });
+  }
+
+  const response = await generateBrief({
+    competitorId,
+    url: competitor.baseUrl,
+    contextData: latestScanContext([...latestByPage.values()]),
+    effort: "low",
+    nocache
+  });
+
+  const payload = extractBriefPayload(response);
+  const threatLevel = parseThreatLevel(payload);
+
+  await prisma.competitor.update({
+    where: { id: competitorId },
+    data: {
+      intelligenceBrief: toJsonValue(payload),
+      threatLevel,
+      briefGeneratedAt: new Date()
+    }
+  });
+
+  return payload;
+}

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -67,6 +67,7 @@ export async function generateCompetitorBrief(competitorId: string, nocache = tr
     throw new Error("Competitor not found");
   }
 
+  const staleThreshold = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7); // 7 days
   const scans = await prisma.scan.findMany({
     where: { page: { competitorId } },
     include: { page: true },
@@ -76,11 +77,16 @@ export async function generateCompetitorBrief(competitorId: string, nocache = tr
   const latestByPage = new Map<string, { pageType: string; pageLabel: string; result: unknown }>();
   for (const scan of scans) {
     if (latestByPage.has(scan.pageId)) continue;
+    if (scan.scannedAt < staleThreshold) continue;
     latestByPage.set(scan.pageId, {
       pageType: scan.page.type,
       pageLabel: scan.page.label,
       result: scan.markdownResult ?? scan.rawResult
     });
+  }
+
+  if (latestByPage.size === 0) {
+    throw new Error("No recent scans available for brief generation");
   }
 
   const response = await generateBrief({


### PR DESCRIPTION
Implements issue #26 App Router endpoints:
- /api/scan
- /api/brief
- /api/deep-dive (SSE + deep_dive persistence)
- /api/competitors
- /api/notifications
- /api/cron (secret-protected)

Also adds `lib/brief.ts` for competitor brief generation.

## Audit/Finalize/Tests
- audit-unified pass completed for scope
- finalize pass completed
- tests-new pass completed for new route + helper logic

## Verification
- npm run lint
- npm run test
- npm run typecheck
