### PR TITLE
Fix: add tests for brief, demo route, and sse utility (0% coverage)

### DIFF
--- a/app/api/__tests__/demo.route.test.ts
+++ b/app/api/__tests__/demo.route.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
+
+const { scanPageMock, demoIpLockCreateMock, demoIpLockDeleteMock, demoScanCountMock, demoScanCreateMock } =
+  vi.hoisted(() => ({
+    scanPageMock: vi.fn(),
+    demoIpLockCreateMock: vi.fn(),
+    demoIpLockDeleteMock: vi.fn(),
+    demoScanCountMock: vi.fn(),
+    demoScanCreateMock: vi.fn()
+  }));
+
+vi.mock("@/lib/scanner", () => ({ scanPage: scanPageMock }));
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    demoIpLock: {
+      create: demoIpLockCreateMock,
+      delete: demoIpLockDeleteMock
+    },
+    demoScan: {
+      count: demoScanCountMock,
+      create: demoScanCreateMock
+    }
+  }
+}));
+
+const SCAN_RESULT = {
+  endpointUsed: "extract/json",
+  usedFallback: false,
+  diffSummary: null,
+  hasChanges: false,
+  rawResult: { tiers: [{ name: "Pro" }] }
+};
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/demo", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body)
+  });
+}
+
+/** Extract the body stream from a Response, asserting it is non-null. */
+function getBody(res: Response): ReadableStream<Uint8Array> {
+  if (!res.body) throw new Error("Response body is null");
+  return res.body;
+}
+
+/** Drain a ReadableStream into an array of ParsedSseEvent-like objects. */
+async function drainStream(stream: ReadableStream<Uint8Array>): Promise<Array<{ event: string; data: unknown }>> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+
+  // Parse SSE blocks
+  const events: Array<{ event: string; data: unknown }> = [];
+  for (const block of text.split("\n\n").filter(Boolean)) {
+    const lines = block.split("\n");
+    const eventLine = lines.find((l) => l.startsWith("event:"));
+    const dataLine = lines.find((l) => l.startsWith("data:"));
+    if (!eventLine || !dataLine) continue;
+    const event = eventLine.slice("event:".length).trim();
+    const raw = dataLine.slice("data:".length).trim();
+    try {
+      events.push({ event, data: JSON.parse(raw) });
+    } catch {
+      events.push({ event, data: raw });
+    }
+  }
+  return events;
+}
+
+describe("POST /api/demo", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    scanPageMock.mockReset();
+    demoIpLockCreateMock.mockReset();
+    demoIpLockDeleteMock.mockReset();
+    demoScanCountMock.mockReset();
+    demoScanCreateMock.mockReset();
+
+    // Default: lock acquired, within daily limit, scan succeeds
+    demoIpLockCreateMock.mockResolvedValue({ ipHash: "abc" });
+    demoIpLockDeleteMock.mockResolvedValue({});
+    demoScanCountMock.mockResolvedValue(0);
+    demoScanCreateMock.mockResolvedValue({});
+    scanPageMock.mockResolvedValue(SCAN_RESULT);
+  });
+
+  it("returns 429 when a concurrent lock is held", async () => {
+    const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint", {
+      code: "P2002",
+      clientVersion: "5.0.0"
+    });
+    demoIpLockCreateMock.mockRejectedValueOnce(p2002);
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/already in progress/i);
+  });
+
+  it("rethrows unexpected DB errors from tryAcquireLock", async () => {
+    demoIpLockCreateMock.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const { POST } = await import("@/app/api/demo/route");
+    await expect(POST(makeRequest({ url: "https://example.com" }))).rejects.toThrow("DB connection lost");
+  });
+
+  it("returns 429 when daily rate limit is exceeded", async () => {
+    demoScanCountMock.mockResolvedValueOnce(3);
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/rate limit/i);
+    // Lock should be released even though we returned early
+    expect(demoIpLockDeleteMock).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/demo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ bad json "
+    });
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid json/i);
+    expect(demoIpLockDeleteMock).toHaveBeenCalled();
+  });
+
+  it("returns 400 when url is missing from body", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/url is required/i);
+    expect(demoIpLockDeleteMock).toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid URL", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "not-a-url" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid url/i);
+  });
+
+  it("returns 400 for non-http protocols", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "ftp://example.com" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not allowed/i);
+  });
+
+  it("returns 400 for localhost URLs", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "http://localhost/anything" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not allowed/i);
+  });
+
+  it("returns 400 for private RFC-1918 IPs", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+
+    for (const url of ["http://192.168.1.1/page", "http://10.0.0.1/page", "http://172.20.0.5/page"]) {
+      const res = await POST(makeRequest({ url }));
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("returns an SSE streaming response for a valid request", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+  });
+
+  it("emits scan:started and scan:endpoint events before scan:complete", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+    const events = await drainStream(getBody(res));
+
+    const eventNames = events.map((e) => e.event);
+    expect(eventNames).toContain("scan:started");
+    expect(eventNames).toContain("scan:endpoint");
+    expect(eventNames).toContain("scan:complete");
+    expect(eventNames.indexOf("scan:started")).toBeLessThan(eventNames.indexOf("scan:complete"));
+  });
+
+  it("scan:endpoint event carries the inferred page type", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+    const events = await drainStream(getBody(res));
+
+    const endpointEvent = events.find((e) => e.event === "scan:endpoint");
+    expect((endpointEvent?.data as { type: string }).type).toBe("pricing");
+  });
+
+  it("scan:complete event contains scan result fields", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const complete = events.find((e) => e.event === "scan:complete");
+    expect(complete).toBeDefined();
+    const data = complete?.data as { endpointUsed: string; result: unknown };
+    expect(data.endpointUsed).toBe("extract/json");
+    expect(data.result).toEqual(SCAN_RESULT.rawResult);
+  });
+
+  it("creates a demoScan record after a successful scan", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    await drainStream(getBody(res));
+
+    expect(demoScanCreateMock).toHaveBeenCalledOnce();
+  });
+
+  it("releases the lock after stream completes successfully", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    await drainStream(getBody(res));
+
+    expect(demoIpLockDeleteMock).toHaveBeenCalled();
+  });
+
+  it("emits scan:error and releases lock when scanPage throws", async () => {
+    scanPageMock.mockRejectedValueOnce(new Error("Scan failed hard"));
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const errorEvent = events.find((e) => e.event === "scan:error");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: string }).error).toBe("Scan failed hard");
+    expect(demoIpLockDeleteMock).toHaveBeenCalled();
+  });
+
+  it("emits generic error message for non-Error throws", async () => {
+    scanPageMock.mockRejectedValueOnce("string rejection");
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const errorEvent = events.find((e) => e.event === "scan:error");
+    expect((errorEvent?.data as { error: string }).error).toBe("Demo scan failed");
+  });
+
+  it("uses x-real-ip header for rate-limiting when present", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }, { "x-real-ip": "1.2.3.4" }));
+
+    // The route should proceed normally — just checking no crash from the header
+    expect(res.status).toBe(200);
+    expect(demoIpLockCreateMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to x-forwarded-for when x-real-ip is absent", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }, { "x-forwarded-for": "5.6.7.8, 9.9.9.9" }));
+
+    expect(res.status).toBe(200);
+    expect(demoIpLockCreateMock).toHaveBeenCalledOnce();
+  });
+
+  // Page type inference tests (exercising inferPageType via scan:endpoint events)
+  const inferCases: Array<[string, string]> = [
+    ["https://example.com/pricing", "pricing"],
+    ["https://example.com/changelog", "changelog"],
+    ["https://example.com/release-notes", "changelog"],
+    ["https://example.com/careers", "careers"],
+    ["https://example.com/jobs", "careers"],
+    ["https://example.com/docs/api", "docs"],
+    ["https://github.com/owner/repo", "github"],
+    ["https://www.linkedin.com/company/acme", "social"],
+    ["https://twitter.com/acme", "social"],
+    ["https://x.com/acme", "social"],
+    ["https://www.youtube.com/c/acme", "social"],
+    ["https://example.com/about", "profile"],
+    ["https://example.com/app/dashboard", "custom"]
+  ];
+
+  describe.each(inferCases)("inferPageType('%s') => '%s'", (url, expectedType) => {
+    it(`infers ${expectedType}`, async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url }));
+      const events = await drainStream(getBody(res));
+
+      const endpointEvent = events.find((e) => e.event === "scan:endpoint");
+      expect((endpointEvent?.data as { type: string }).type).toBe(expectedType);
+    });
+  });
+
+  it("passes isDemo=true to scanPage", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    await drainStream(getBody(res));
+
+    expect(scanPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isDemo: true })
+    );
+  });
+
+  it("passes customTask for custom page type", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/dashboard" }));
+    await drainStream(getBody(res));
+
+    expect(scanPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "custom",
+        customTask: expect.stringContaining("competitive intelligence")
+      })
+    );
+  });
+
+  it("does not pass customTask for non-custom page types", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+    await drainStream(getBody(res));
+
+    expect(scanPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "pricing", customTask: undefined })
+    );
+  });
+});

--- a/app/api/__tests__/demo.route.test.ts
+++ b/app/api/__tests__/demo.route.test.ts
@@ -2,14 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 
-const { scanPageMock, demoIpLockCreateMock, demoIpLockDeleteMock, demoScanCountMock, demoScanCreateMock } =
-  vi.hoisted(() => ({
+const { scanPageMock, demoIpLockCreateMock, demoIpLockDeleteMock, demoScanCountMock, demoScanCreateMock } = vi.hoisted(
+  () => ({
     scanPageMock: vi.fn(),
     demoIpLockCreateMock: vi.fn(),
     demoIpLockDeleteMock: vi.fn(),
     demoScanCountMock: vi.fn(),
     demoScanCreateMock: vi.fn()
-  }));
+  })
+);
 
 vi.mock("@/lib/scanner", () => ({ scanPage: scanPageMock }));
 vi.mock("@/lib/db/client", () => ({
@@ -323,9 +324,7 @@ describe("POST /api/demo", () => {
     const res = await POST(makeRequest({ url: "https://example.com" }));
     await drainStream(getBody(res));
 
-    expect(scanPageMock).toHaveBeenCalledWith(
-      expect.objectContaining({ isDemo: true })
-    );
+    expect(scanPageMock).toHaveBeenCalledWith(expect.objectContaining({ isDemo: true }));
   });
 
   it("passes customTask for custom page type", async () => {
@@ -346,8 +345,6 @@ describe("POST /api/demo", () => {
     const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     await drainStream(getBody(res));
 
-    expect(scanPageMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "pricing", customTask: undefined })
-    );
+    expect(scanPageMock).toHaveBeenCalledWith(expect.objectContaining({ type: "pricing", customTask: undefined }));
   });
 });

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  competitorFindUniqueMock,
+  scanFindManyMock,
+  competitorUpdateMock,
+  generateBriefMock
+} = vi.hoisted(() => ({
+  competitorFindUniqueMock: vi.fn(),
+  scanFindManyMock: vi.fn(),
+  competitorUpdateMock: vi.fn(),
+  generateBriefMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: {
+      findUnique: competitorFindUniqueMock,
+      update: competitorUpdateMock
+    },
+    scan: {
+      findMany: scanFindManyMock
+    }
+  }
+}));
+
+vi.mock("@/lib/tabstack/generate", () => ({
+  generateBrief: generateBriefMock
+}));
+
+const COMPETITOR = {
+  id: "cmp_1",
+  name: "Acme",
+  baseUrl: "https://acme.com",
+  pages: [{ id: "page_1" }]
+};
+
+function makeRecentScan(overrides = {}) {
+  const recent = new Date(Date.now() - 1000 * 60 * 60); // 1 hour ago
+  return {
+    id: "scan_1",
+    pageId: "page_1",
+    scannedAt: recent,
+    markdownResult: "## Pricing\nStarter: $10/mo",
+    rawResult: null,
+    page: { type: "pricing", label: "Pricing Page" },
+    ...overrides
+  };
+}
+
+function makeStaleScan(overrides = {}) {
+  const stale = new Date(Date.now() - 1000 * 60 * 60 * 24 * 8); // 8 days ago
+  return {
+    id: "scan_old",
+    pageId: "page_1",
+    scannedAt: stale,
+    markdownResult: "## Old Pricing",
+    rawResult: null,
+    page: { type: "pricing", label: "Pricing Page" },
+    ...overrides
+  };
+}
+
+describe("generateCompetitorBrief", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    competitorFindUniqueMock.mockReset();
+    scanFindManyMock.mockReset();
+    competitorUpdateMock.mockReset();
+    generateBriefMock.mockReset();
+
+    competitorFindUniqueMock.mockResolvedValue(COMPETITOR);
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+    competitorUpdateMock.mockResolvedValue({});
+    generateBriefMock.mockResolvedValue({
+      threat_level: "Medium",
+      positioning_opportunity: "Fill the docs gap",
+      content_opportunity: "Write TypeScript guides",
+      product_opportunity: "Better SDK ergonomics",
+      threat_reasoning: "Growing but behind on DX",
+      watch_list: ["pricing change"]
+    });
+  });
+
+  it("throws when competitor is not found", async () => {
+    competitorFindUniqueMock.mockResolvedValueOnce(null);
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+
+    await expect(generateCompetitorBrief("missing")).rejects.toThrow("Competitor not found");
+    expect(generateBriefMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when no recent scans are available", async () => {
+    scanFindManyMock.mockResolvedValueOnce([makeStaleScan()]);
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow(
+      "No recent scans available for brief generation"
+    );
+    expect(generateBriefMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when scan list is empty", async () => {
+    scanFindManyMock.mockResolvedValueOnce([]);
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow(
+      "No recent scans available for brief generation"
+    );
+  });
+
+  it("calls generateBrief with competitor baseUrl and nocache=true by default", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    expect(generateBriefMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://acme.com",
+        effort: "low",
+        nocache: true
+      })
+    );
+  });
+
+  it("passes nocache=false when explicitly set", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1", false);
+
+    expect(generateBriefMock).toHaveBeenCalledWith(
+      expect.objectContaining({ nocache: false })
+    );
+  });
+
+  it("passes competitorId in generateBrief params", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    expect(generateBriefMock).toHaveBeenCalledWith(
+      expect.objectContaining({ competitorId: "cmp_1" })
+    );
+  });
+
+  it("uses markdownResult when available", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    const call = generateBriefMock.mock.calls[0][0];
+    expect(call.contextData).toContain("## Pricing");
+  });
+
+  it("falls back to rawResult when markdownResult is null", async () => {
+    scanFindManyMock.mockResolvedValueOnce([
+      makeRecentScan({ markdownResult: null, rawResult: { tiers: [{ name: "Pro" }] } })
+    ]);
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    const call = generateBriefMock.mock.calls[0][0];
+    expect(call.contextData).toContain("tiers");
+  });
+
+  it("persists intelligence brief and threat level on competitor", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "cmp_1" },
+        data: expect.objectContaining({
+          threatLevel: "Medium",
+          briefGeneratedAt: expect.any(Date)
+        })
+      })
+    );
+  });
+
+  it("returns the payload from generateBrief", async () => {
+    const mockPayload = {
+      threat_level: "High",
+      positioning_opportunity: "Dominate docs",
+      content_opportunity: "More examples",
+      product_opportunity: "Better onboarding",
+      threat_reasoning: "Aggressive pricing",
+      watch_list: ["funding round"]
+    };
+    generateBriefMock.mockResolvedValueOnce(mockPayload);
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    const result = await generateCompetitorBrief("cmp_1");
+
+    expect(result).toEqual(mockPayload);
+  });
+
+  it("extracts payload from data envelope when present", async () => {
+    const inner = {
+      threat_level: "Low",
+      positioning_opportunity: "Niche focus",
+      content_opportunity: "Case studies",
+      product_opportunity: "Integrations",
+      threat_reasoning: "Small market share",
+      watch_list: []
+    };
+    generateBriefMock.mockResolvedValueOnce({ data: inner });
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    const result = await generateCompetitorBrief("cmp_1");
+
+    expect(result).toEqual(inner);
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ threatLevel: "Low" })
+      })
+    );
+  });
+
+  it("sets threatLevel to null when threat_level is not a valid string", async () => {
+    generateBriefMock.mockResolvedValueOnce({ threat_level: "Unknown" });
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ threatLevel: null })
+      })
+    );
+  });
+
+  it("sets threatLevel to null when response is not a plain object", async () => {
+    generateBriefMock.mockResolvedValueOnce("just a string");
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ threatLevel: null })
+      })
+    );
+  });
+
+  it("deduplicates scans by pageId — uses only the latest scan per page", async () => {
+    const recent = makeRecentScan({ id: "scan_new", scannedAt: new Date(Date.now() - 1000 * 60 * 30) });
+    const older = makeRecentScan({ id: "scan_older", scannedAt: new Date(Date.now() - 1000 * 60 * 60 * 2) });
+    // Same pageId — findMany returns them newest-first per orderBy: scannedAt desc
+    scanFindManyMock.mockResolvedValueOnce([recent, older]);
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    // contextData should contain only one entry (the most recent)
+    const call = generateBriefMock.mock.calls[0][0];
+    const parsed = JSON.parse(call.contextData) as unknown[];
+    expect(parsed).toHaveLength(1);
+  });
+
+  it("ignores scans older than 7 days but includes scans within the window", async () => {
+    const recentScan = makeRecentScan({ pageId: "page_2", page: { type: "changelog", label: "Changelog" } });
+    const staleScan = makeStaleScan(); // pageId: page_1
+    scanFindManyMock.mockResolvedValueOnce([recentScan, staleScan]);
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await generateCompetitorBrief("cmp_1");
+
+    // Only the recent scan (page_2) should be in context; stale scan skipped
+    const call = generateBriefMock.mock.calls[0][0];
+    const parsed = JSON.parse(call.contextData) as Array<{ page_type: string }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].page_type).toBe("changelog");
+  });
+
+  it("propagates errors from generateBrief", async () => {
+    generateBriefMock.mockRejectedValueOnce(new Error("Tabstack API failure"));
+
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow("Tabstack API failure");
+    expect(competitorUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts all three valid threat levels — High, Medium, Low", async () => {
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+
+    for (const level of ["High", "Medium", "Low"] as const) {
+      generateBriefMock.mockResolvedValueOnce({ threat_level: level });
+      await generateCompetitorBrief("cmp_1");
+
+      const lastCall = competitorUpdateMock.mock.calls.at(-1) as Array<unknown>;
+      const data = (lastCall[0] as { data: { threatLevel: string } }).data;
+      expect(data.threatLevel).toBe(level);
+    }
+  });
+});

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -1,11 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  competitorFindUniqueMock,
-  scanFindManyMock,
-  competitorUpdateMock,
-  generateBriefMock
-} = vi.hoisted(() => ({
+const { competitorFindUniqueMock, scanFindManyMock, competitorUpdateMock, generateBriefMock } = vi.hoisted(() => ({
   competitorFindUniqueMock: vi.fn(),
   scanFindManyMock: vi.fn(),
   competitorUpdateMock: vi.fn(),
@@ -94,9 +89,7 @@ describe("generateCompetitorBrief", () => {
     scanFindManyMock.mockResolvedValueOnce([makeStaleScan()]);
     const { generateCompetitorBrief } = await import("@/lib/brief");
 
-    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow(
-      "No recent scans available for brief generation"
-    );
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow("No recent scans available for brief generation");
     expect(generateBriefMock).not.toHaveBeenCalled();
   });
 
@@ -104,9 +97,7 @@ describe("generateCompetitorBrief", () => {
     scanFindManyMock.mockResolvedValueOnce([]);
     const { generateCompetitorBrief } = await import("@/lib/brief");
 
-    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow(
-      "No recent scans available for brief generation"
-    );
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow("No recent scans available for brief generation");
   });
 
   it("calls generateBrief with competitor baseUrl and nocache=true by default", async () => {
@@ -126,18 +117,14 @@ describe("generateCompetitorBrief", () => {
     const { generateCompetitorBrief } = await import("@/lib/brief");
     await generateCompetitorBrief("cmp_1", false);
 
-    expect(generateBriefMock).toHaveBeenCalledWith(
-      expect.objectContaining({ nocache: false })
-    );
+    expect(generateBriefMock).toHaveBeenCalledWith(expect.objectContaining({ nocache: false }));
   });
 
   it("passes competitorId in generateBrief params", async () => {
     const { generateCompetitorBrief } = await import("@/lib/brief");
     await generateCompetitorBrief("cmp_1");
 
-    expect(generateBriefMock).toHaveBeenCalledWith(
-      expect.objectContaining({ competitorId: "cmp_1" })
-    );
+    expect(generateBriefMock).toHaveBeenCalledWith(expect.objectContaining({ competitorId: "cmp_1" }));
   });
 
   it("uses markdownResult when available", async () => {

--- a/lib/utils/__tests__/sse.test.ts
+++ b/lib/utils/__tests__/sse.test.ts
@@ -28,10 +28,10 @@ describe("parseSseChunk", () => {
   });
 
   it("parses multiple SSE blocks in one chunk", () => {
-    const chunk = [
-      'event: scan:started\ndata: {"url":"https://example.com"}',
-      'event: scan:complete\ndata: {"result":"ok"}'
-    ].join("\n\n") + "\n\n";
+    const chunk =
+      ['event: scan:started\ndata: {"url":"https://example.com"}', 'event: scan:complete\ndata: {"result":"ok"}'].join(
+        "\n\n"
+      ) + "\n\n";
 
     const result = parseSseChunk(chunk);
 
@@ -106,11 +106,8 @@ describe("parseSseChunk", () => {
   });
 
   it("handles mixed valid and invalid blocks", () => {
-    const chunk = [
-      "event: good\ndata: 1",
-      "event: bad\ndata: {broken",
-      'event: good2\ndata: {"ok":true}'
-    ].join("\n\n") + "\n\n";
+    const chunk =
+      ["event: good\ndata: 1", "event: bad\ndata: {broken", 'event: good2\ndata: {"ok":true}'].join("\n\n") + "\n\n";
 
     const result = parseSseChunk(chunk);
 
@@ -130,7 +127,7 @@ describe("parseSseChunk", () => {
   });
 
   it("handles multiple blank lines between blocks gracefully", () => {
-    const chunk = 'event: first\ndata: 1\n\n\n\nevent: second\ndata: 2\n\n';
+    const chunk = "event: first\ndata: 1\n\n\n\nevent: second\ndata: 2\n\n";
     const result = parseSseChunk(chunk);
 
     // The extra blank line block (empty string after filtering) is dropped

--- a/lib/utils/__tests__/sse.test.ts
+++ b/lib/utils/__tests__/sse.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { parseSseChunk } from "@/lib/utils/sse";
+import type { ParsedSseEvent } from "@/lib/utils/sse";
+
+describe("parseSseChunk", () => {
+  it("returns an empty array for an empty string", () => {
+    expect(parseSseChunk("")).toEqual([]);
+  });
+
+  it("returns a raw-string event when JSON in an incomplete block cannot be parsed", () => {
+    // A block without a trailing \n\n is still parsed (filter(Boolean) keeps it).
+    // The invalid JSON falls back to the raw string.
+    const result = parseSseChunk("event: scan:started\ndata: {");
+    expect(result).toHaveLength(1);
+    expect(result[0].event).toBe("scan:started");
+    expect(result[0].data).toBe("{");
+  });
+
+  it("parses a single well-formed SSE block", () => {
+    const chunk = 'event: scan:started\ndata: {"url":"https://example.com"}\n\n';
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      event: "scan:started",
+      data: { url: "https://example.com" }
+    });
+  });
+
+  it("parses multiple SSE blocks in one chunk", () => {
+    const chunk = [
+      'event: scan:started\ndata: {"url":"https://example.com"}',
+      'event: scan:complete\ndata: {"result":"ok"}'
+    ].join("\n\n") + "\n\n";
+
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].event).toBe("scan:started");
+    expect(result[1].event).toBe("scan:complete");
+  });
+
+  it("trims whitespace from event name", () => {
+    const chunk = "event:  my-event  \ndata: null\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].event).toBe("my-event");
+  });
+
+  it("trims whitespace from data value before JSON parsing", () => {
+    const chunk = 'event: test\ndata:   {"key":"value"}   \n\n';
+    const result = parseSseChunk(chunk);
+
+    expect(result[0].data).toEqual({ key: "value" });
+  });
+
+  it("returns raw string when JSON parsing fails", () => {
+    const chunk = "event: test\ndata: not valid json\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ event: "test", data: "not valid json" });
+  });
+
+  it("skips blocks missing an event line", () => {
+    const chunk = 'data: {"value":1}\n\n';
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips blocks missing a data line", () => {
+    const chunk = "event: scan:started\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("parses JSON null as data", () => {
+    const chunk = "event: ping\ndata: null\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result[0].data).toBeNull();
+  });
+
+  it("parses JSON boolean as data", () => {
+    const chunk = "event: toggle\ndata: true\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result[0].data).toBe(true);
+  });
+
+  it("parses JSON number as data", () => {
+    const chunk = "event: count\ndata: 42\n\n";
+    const result = parseSseChunk(chunk);
+
+    expect(result[0].data).toBe(42);
+  });
+
+  it("parses JSON array as data", () => {
+    const chunk = 'event: list\ndata: [1,"two",3]\n\n';
+    const result = parseSseChunk(chunk);
+
+    expect(result[0].data).toEqual([1, "two", 3]);
+  });
+
+  it("handles mixed valid and invalid blocks", () => {
+    const chunk = [
+      "event: good\ndata: 1",
+      "event: bad\ndata: {broken",
+      'event: good2\ndata: {"ok":true}'
+    ].join("\n\n") + "\n\n";
+
+    const result = parseSseChunk(chunk);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ event: "good", data: 1 });
+    expect(result[1]).toEqual({ event: "bad", data: "{broken" });
+    expect(result[2]).toEqual({ event: "good2", data: { ok: true } });
+  });
+
+  it("returns typed ParsedSseEvent objects", () => {
+    const chunk = 'event: scan:endpoint\ndata: {"type":"pricing"}\n\n';
+    const result = parseSseChunk(chunk);
+    const event: ParsedSseEvent = result[0];
+
+    expect(event.event).toBe("scan:endpoint");
+    expect((event.data as { type: string }).type).toBe("pricing");
+  });
+
+  it("handles multiple blank lines between blocks gracefully", () => {
+    const chunk = 'event: first\ndata: 1\n\n\n\nevent: second\ndata: 2\n\n';
+    const result = parseSseChunk(chunk);
+
+    // The extra blank line block (empty string after filtering) is dropped
+    const events = result.map((e) => e.data);
+    expect(events).toContain(1);
+    expect(events).toContain(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lib/__tests__/brief.test.ts` — 17 tests covering `generateCompetitorBrief`: competitor-not-found, no-recent-scans, stale-scan filtering, page deduplication, `data` envelope unwrapping, all three threat levels, nocache passthrough, and error propagation
- Adds `app/api/__tests__/demo.route.test.ts` — 35 tests covering `POST /api/demo`: concurrent-lock 429, daily rate-limit 429, all 400 validation paths (bad JSON, missing URL, invalid URL, disallowed protocols, private IPs), SSE event sequence, page-type inference for all 13 URL patterns, `isDemo` flag, `customTask` injection, and error/fallback SSE events
- Adds `lib/utils/__tests__/sse.test.ts` — 16 tests covering `parseSseChunk`: empty input, single and multi-block parsing, JSON type variations (null, boolean, number, array), invalid JSON fallback to raw string, missing event/data line skipping, and whitespace trimming

All three files had 0% coverage before this PR. Coverage after:
- `lib/brief.ts`: 97.29% statements / 91.66% branches
- `app/api/demo/route.ts`: 98.82% statements / 93.9% branches
- `lib/utils/sse.ts`: 100% across all metrics

Resolves coverage gaps identified in the release audit.

## Test plan

- [x] `npm run test:coverage` — 278 tests pass, all files above 80% thresholds
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [x] No source files modified — only test files added

🤖 Generated with [Claude Code](https://claude.com/claude-code)