### PR TITLE
fix: remove redundant prisma generate step from GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ jobs:
       - run: npm ci
 
       - name: Deploy to Netlify
+        # `prisma generate` is intentionally omitted here. Prisma 7 requires
+        # DATABASE_URL at generate time (via prisma.config.ts), which is not
+        # available in the GitHub Actions environment. The netlify.toml build
+        # command (`npx prisma generate && npm run build`) runs it inside
+        # Netlify's own build environment where DATABASE_URL is configured.
         run: npx netlify-cli deploy --build --prod --dir=.next
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Prisma Generate
-        run: npx prisma generate
-
       - name: Deploy to Netlify
         run: npx netlify-cli deploy --build --prod --dir=.next
         env:


### PR DESCRIPTION
## Problem

Daily scans stopped after April 14. Root cause investigation revealed **two compounding bugs**:

1. **The deployed scheduled function times out** — the April 14 production deploy has `scheduled-scan.ts` calling `/api/cron` via HTTP, which hits a regular 26-second serverless timeout before any scans complete.

2. **Every deploy since April 14 has failed** — the real fix (PR #69, which changed the function to call `runScans()` directly) was never shipped because the GitHub Actions workflow fails at:
   ```
   PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL.
   ```
   Prisma 7 requires `DATABASE_URL` at `prisma generate` time via `prisma.config.ts`. It's not available as a secret in the GitHub Actions environment.

## Fix

Remove the standalone `npx prisma generate` step from the GitHub Actions workflow.

It's redundant — `netlify deploy --build` runs the `netlify.toml` build command (`npx prisma generate && npm run build`) inside Netlify's own build environment, where `DATABASE_URL` is properly configured.

## Test Plan

- [ ] Merge this PR → GitHub Actions deploy workflow succeeds
- [ ] Confirm Netlify deploys the latest code (including PR #69's direct `runScans()` call)
- [ ] Verify next 6 AM UTC run produces a new scan record in the DB