### PR TITLE
feat: add Apify as a competitor

### DIFF
--- a/rivals.config.json
+++ b/rivals.config.json
@@ -96,6 +96,23 @@
       ]
     },
     {
+      "name": "Apify",
+      "slug": "apify",
+      "url": "https://apify.com",
+      "pages": [
+        { "label": "Homepage", "url": "https://apify.com", "type": "homepage" },
+        { "label": "Pricing", "url": "https://apify.com/pricing", "type": "pricing", "geo_target": "US" },
+        { "label": "Changelog", "url": "https://apify.com/change-log", "type": "changelog" },
+        { "label": "Careers", "url": "https://apify.com/jobs", "type": "careers" },
+        { "label": "GitHub", "url": "https://github.com/apify/crawlee", "type": "github" },
+        { "label": "Docs", "url": "https://docs.apify.com", "type": "docs" },
+        { "label": "Blog", "url": "https://blog.apify.com", "type": "blog" },
+        { "label": "About", "url": "https://apify.com/about", "type": "profile" },
+        { "label": "Twitter/X", "url": "https://x.com/apify", "type": "social" },
+        { "label": "Reviews", "url": "https://www.producthunt.com/products/apify/reviews", "type": "reviews" }
+      ]
+    },
+    {
       "name": "LangChain Browser Tools",
       "slug": "langchain-browser",
       "url": "https://langchain.com",


### PR DESCRIPTION
## Summary
- Adds **Apify** (https://apify.com) to `rivals.config.json` with the standard 10-page set: homepage, pricing, changelog, careers, GitHub, docs, blog, about, Twitter/X, and reviews.
- GitHub entry points to [`apify/crawlee`](https://github.com/apify/crawlee) — their flagship OSS web-scraping library (22.9k stars) — matching the convention of other competitors pointing to their main repo.
- All 10 URLs verified live before commit (including the `/change-log` path, which uses a hyphen unlike most competitors' `/changelog`).

## Test plan
- [ ] Merge triggers Netlify auto-deploy.
- [ ] After deploy, Apify appears on the dashboard and scans successfully.
- [ ] Spot-check a scan log to confirm all 10 pages resolve (watch for the `change-log` hyphen).