### PR TITLE
infra: run db:seed during Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npx prisma generate && npm run build"
+  command = "npx prisma generate && npm run build && npx tsx scripts/seed.ts"
   publish = ".next"
   functions = "netlify/functions"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,18 @@
 [build]
-  command = "npx prisma generate && npm run build && npx tsx scripts/seed.ts"
+  command = "npx prisma generate && npm run build"
   publish = ".next"
   functions = "netlify/functions"
+
+# Seed is production-only.
+#
+# The [build] block above applies to every Netlify context (production,
+# deploy-preview, branch-deploy). Seeding during a preview build would
+# upsert competitor and page rows against whatever DATABASE_URL that
+# context has — which, if shared with production, means any PR build
+# could mutate live data. Scope seeding to the production context so
+# previews stay read-only.
+[context.production]
+  command = "npx prisma generate && npm run build && npx tsx scripts/seed.ts"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- Appends `npx tsx scripts/seed.ts` to the Netlify build command so every deploy reconciles Postgres with `rivals.config.json`.
- Before: adding a competitor to the config file landed in code but not in the DB, so the dashboard never showed it without a manual seed run. Apify (PR #73) is the current example — merged and deployed, but not visible on the live site.
- After: the committed config is the single source of truth; new competitors appear on the next deploy.

## Why this is safe
- `scripts/seed.ts` is idempotent — it upserts competitors by `slug` and reconciles pages per competitor.
- `tsx` is already in `devDependencies`; Netlify installs those during build.
- No changes to the GitHub Actions deploy workflow — it was already deferring Prisma/build to Netlify's build env (where `DATABASE_URL` is configured).

## Test plan
- [ ] Merge and confirm the Netlify build log shows `Seeded Apify (apify)` (plus the other 7 competitors).
- [ ] Confirm Apify appears on https://rival-676.netlify.app after the deploy completes.
- [ ] Spot-check that existing competitors still render correctly (upsert should be a no-op for unchanged rows).