### PR TITLE
fix(brief): calibrate threat-level prompt with explicit rubric

### DIFF
--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -212,7 +212,14 @@ produce a structured brief covering:
 1. Positioning opportunity — what gap does their weakness create?
 2. Content opportunity — what topics should you own based on their blind spots?
 3. Product opportunity — what are developers complaining about that you could solve?
-4. Threat level: High / Medium / Low with one sentence of reasoning
+4. Threat level — rate as High, Medium, or Low using this rubric, with one sentence of reasoning:
+   - High: Direct feature AND audience overlap, AND active momentum in the last ~30 days
+     (recent launches, relevant hiring, pricing moves, or notable GitHub/community growth).
+   - Medium: Partial overlap (audience OR use case, not both), OR full overlap with stalled
+     execution (no recent shipping, hiring, or pricing activity).
+   - Low: Adjacent space, different ICP, or clear wind-down signals.
+   Reserve High for competitors with BOTH overlap AND momentum. When evidence is mixed,
+   sparse, or ambiguous, default to Medium rather than High.
 5. Watch list: 2-3 signals to monitor next cycle
 Be direct and specific. No generic advice.
 


### PR DESCRIPTION
## Summary
- The threat-level prompt in `lib/tabstack/generate.ts` was a single underspecified line, so the LLM rated nearly every competitor **High** and the dashboard's threat matrix lost its triage value.
- Replaces it with a three-tier rubric requiring **both** feature/audience overlap **and** ~30-day momentum for a High rating, plus an explicit *"default to Medium when evidence is mixed"* anchor to counter LLM high-bias on underspecified enum judgments.
- Schema, field names, storage, and downstream rendering are unchanged — only the free-text `instructions` string is edited.

## Rubric
- **High**: Direct feature AND audience overlap, AND active momentum in the last ~30 days (launches, relevant hiring, pricing moves, notable GitHub/community growth).
- **Medium**: Partial overlap (audience OR use case, not both), OR full overlap with stalled execution.
- **Low**: Adjacent space, different ICP, or clear wind-down signals.
- Default to Medium when evidence is mixed, sparse, or ambiguous.

## Verification
- `npm run typecheck` — clean.
- `npx vitest run lib/tabstack/__tests__/generate.test.ts lib/__tests__/brief.test.ts` — 34/34 pass.
- DX note added locally (`notes-local/tabstack-dx-notes.md`, gitignored) capturing the observation for upstream feedback.

## Test plan
- [ ] After merge, trigger a brief regeneration on 2-3 competitors and confirm the threat spread is no longer uniformly High.
- [ ] Sanity-check the reasoning sentence references the rubric dimensions (overlap, momentum).
- [ ] Watch for overcorrection — if everything flips to Medium, the rubric may need tightening on the High criteria.