### PR TITLE
fix(scanner): stop flagging homepages as edited on every scan

### DIFF
--- a/lib/__tests__/scanner.test.ts
+++ b/lib/__tests__/scanner.test.ts
@@ -122,6 +122,75 @@ describe("scanPage", () => {
     );
   });
 
+  it("skips the diff LLM call when the current markdown matches the previous scan", async () => {
+    scanFindFirstMock.mockResolvedValueOnce({
+      id: "scan_prev",
+      markdownResult: "## Updates\n\n- Shipped v2\n",
+      rawResult: { content: "## Updates\n\n- Shipped v2\n" }
+    });
+    extractMarkdownMock.mockResolvedValueOnce({
+      content: "## Updates\r\n\r\n- Shipped v2   \n",
+      url: "https://example.com/changelog"
+    });
+
+    const { scanPage } = await import("@/lib/scanner");
+
+    const result = await scanPage({
+      competitorId: "cmp_1",
+      pageId: "page_1",
+      url: "https://example.com/changelog",
+      type: "changelog"
+    });
+
+    expect(generateDiffMock).not.toHaveBeenCalled();
+    expect(result.hasChanges).toBe(false);
+    expect(result.diffSummary).toBeNull();
+    expect(scanCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          hasChanges: false,
+          diffSummary: null
+        })
+      })
+    );
+  });
+
+  it("passes currentContent to the diff call when content genuinely differs", async () => {
+    scanFindFirstMock.mockResolvedValueOnce({
+      id: "scan_prev",
+      markdownResult: "## Updates\n\n- Shipped v1",
+      rawResult: { content: "## Updates\n\n- Shipped v1" }
+    });
+    extractMarkdownMock.mockResolvedValueOnce({
+      content: "## Updates\n\n- Shipped v2",
+      url: "https://example.com/changelog"
+    });
+    generateDiffMock.mockResolvedValueOnce({
+      data: {
+        added: ["Shipped v2"],
+        changed: [],
+        removed: ["Shipped v1"],
+        summary: "Bumped shipped version"
+      }
+    });
+
+    const { scanPage } = await import("@/lib/scanner");
+
+    await scanPage({
+      competitorId: "cmp_1",
+      pageId: "page_1",
+      url: "https://example.com/changelog",
+      type: "changelog"
+    });
+
+    expect(generateDiffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousContent: "## Updates\n\n- Shipped v1",
+        currentContent: "## Updates\n\n- Shipped v2"
+      })
+    );
+  });
+
   it("routes changelog pages to markdown and generates diff when previous scan exists", async () => {
     scanFindFirstMock.mockResolvedValueOnce({
       id: "scan_prev",

--- a/lib/scanner.ts
+++ b/lib/scanner.ts
@@ -257,6 +257,22 @@ function toPreviousContent(scan: { markdownResult: string | null; rawResult: unk
   return stringifyUnknown(scan.rawResult ?? "");
 }
 
+/**
+ * Normalize scan content so that cosmetic differences (line endings, trailing
+ * whitespace, stray blank lines) don't register as changes. Used only for the
+ * equality short-circuit in the diff flow — the original content is still sent
+ * to the diff LLM when a real difference exists.
+ */
+function normalizeForDiff(content: string): string {
+  return content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/\s+$/, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function buildAutomateTask(input: ScanPageInput): string {
   if (input.customTask && input.customTask.trim().length > 0) {
     return input.customTask.trim();
@@ -590,19 +606,34 @@ export async function scanPage(input: ScanPageInput): Promise<ScanPageOutput> {
   let hasChanges = false;
 
   if (previousScan) {
-    const diffResponse = await generateDiff({
-      competitorId: input.competitorId,
-      pageId,
-      url: input.url,
-      previousContent: toPreviousContent(previousScan),
-      effort: "low",
-      nocache,
-      geoTarget: input.geoTarget,
-      isDemo: input.isDemo
+    const previousContent = toPreviousContent(previousScan);
+    const currentContent = toPreviousContent({
+      markdownResult: scanResult.markdownResult,
+      rawResult: scanResult.rawResult
     });
-    const parsed = extractDiffPayload(diffResponse);
-    diffSummary = parsed.summary;
-    hasChanges = parsed.hasChanges;
+
+    if (normalizeForDiff(previousContent) === normalizeForDiff(currentContent)) {
+      // Normalized content is identical — skip the diff LLM call entirely.
+      // Prevents false positives from dynamic re-fetches and saves a
+      // generate.json round-trip on no-op scans.
+      hasChanges = false;
+      diffSummary = null;
+    } else {
+      const diffResponse = await generateDiff({
+        competitorId: input.competitorId,
+        pageId,
+        url: input.url,
+        previousContent,
+        currentContent,
+        effort: "low",
+        nocache,
+        geoTarget: input.geoTarget,
+        isDemo: input.isDemo
+      });
+      const parsed = extractDiffPayload(diffResponse);
+      diffSummary = parsed.summary;
+      hasChanges = parsed.hasChanges;
+    }
   }
 
   const createdScan = persistScan

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -90,6 +90,46 @@ describe("generateDiff", () => {
     expect(sdkCall.instructions).toContain("Compare these two versions");
   });
 
+  it("uses the two-version prompt when currentContent is provided (even if empty)", async () => {
+    const { generateDiff } = await import("@/lib/tabstack/generate");
+    generateJsonMock.mockResolvedValue({ added: [], changed: [], removed: [], summary: "" });
+
+    await generateDiff({
+      url: "https://example.com/changelog",
+      previousContent: "PREV_MARKER",
+      currentContent: "",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    // Empty string is an authoritative "everything removed" snapshot, not a
+    // signal to fall back to the single-version prompt. The instructions
+    // should be the two-version comparator with an empty current section.
+    expect(sdkCall.instructions).toContain("Compare the two versions");
+    expect(sdkCall.instructions).toContain("PREV_MARKER");
+    expect(sdkCall.instructions).toContain("Current version:");
+    expect(sdkCall.instructions).not.toContain("Compare these two versions of a competitor page.\nList");
+  });
+
+  it("passes both previousContent and currentContent into the two-version prompt", async () => {
+    const { generateDiff } = await import("@/lib/tabstack/generate");
+    generateJsonMock.mockResolvedValue({ added: [], changed: [], removed: [], summary: "" });
+
+    await generateDiff({
+      url: "https://example.com/changelog",
+      previousContent: "PREV_MARKER",
+      currentContent: "CURR_MARKER",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    expect(sdkCall.instructions).toContain("Compare the two versions");
+    expect(sdkCall.instructions).toContain("PREV_MARKER");
+    expect(sdkCall.instructions).toContain("CURR_MARKER");
+  });
+
   it("injects previousContent into instructions and maps high effort", async () => {
     const { generateDiff } = await import("@/lib/tabstack/generate");
     generateJsonMock.mockResolvedValue({ added: [], changed: [], removed: [], summary: "" });

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -111,9 +111,7 @@ export async function generateDiff(input: GenerateDiffInput): Promise<GenerateJs
 
   const rawCurrentContent = input.currentContent;
   const hasCurrentContent = typeof rawCurrentContent === "string" && rawCurrentContent.length > 0;
-  const currentContent = hasCurrentContent
-    ? (rawCurrentContent as string).slice(0, MAX_CONTEXT_LENGTH)
-    : null;
+  const currentContent = hasCurrentContent ? (rawCurrentContent as string).slice(0, MAX_CONTEXT_LENGTH) : null;
   if (hasCurrentContent && (rawCurrentContent as string).length > MAX_CONTEXT_LENGTH) {
     process.emitWarning(
       `[generateDiff] currentContent truncated from ${(rawCurrentContent as string).length} to ${MAX_CONTEXT_LENGTH} chars`,

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -109,17 +109,21 @@ export async function generateDiff(input: GenerateDiffInput): Promise<GenerateJs
     );
   }
 
+  // Treat any string as an authoritative snapshot — including "". An empty
+  // currentContent is a valid "everything was removed" signal; falling back
+  // to the live-fetch prompt path here would both miss that diff and
+  // reintroduce the double-fetch false positives this module exists to fix.
   const rawCurrentContent = input.currentContent;
-  const hasCurrentContent = typeof rawCurrentContent === "string" && rawCurrentContent.length > 0;
-  const currentContent = hasCurrentContent ? (rawCurrentContent as string).slice(0, MAX_CONTEXT_LENGTH) : null;
-  if (hasCurrentContent && (rawCurrentContent as string).length > MAX_CONTEXT_LENGTH) {
+  const hasCurrentContent = typeof rawCurrentContent === "string";
+  const currentContent = hasCurrentContent ? rawCurrentContent.slice(0, MAX_CONTEXT_LENGTH) : null;
+  if (hasCurrentContent && rawCurrentContent.length > MAX_CONTEXT_LENGTH) {
     process.emitWarning(
-      `[generateDiff] currentContent truncated from ${(rawCurrentContent as string).length} to ${MAX_CONTEXT_LENGTH} chars`,
+      `[generateDiff] currentContent truncated from ${rawCurrentContent.length} to ${MAX_CONTEXT_LENGTH} chars`,
       { code: "RIVAL_CONTEXT_TRUNCATED" }
     );
   }
 
-  const instructions = currentContent
+  const instructions = hasCurrentContent
     ? `Compare the two versions of a competitor page provided below.
 Base your diff ONLY on these two snapshots — do not rely on any live content
 that may be fetched alongside this request. Both snapshots were captured by

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -78,6 +78,15 @@ export type GenerateDiffInput = {
   pageId?: string | null;
   url: string;
   previousContent: string;
+  /**
+   * The just-captured version of the page from the current scan cycle. When
+   * provided, the diff compares previousContent against this snapshot rather
+   * than whatever generate.json re-fetches from the live URL. This avoids
+   * false positives caused by dynamic content (rotating hero copy, timestamps,
+   * A/B variants) differing between the primary scan fetch and the diff fetch
+   * seconds later.
+   */
+  currentContent?: string;
   effort: TabstackEffort;
   nocache: boolean;
   geoTarget?: string | null;
@@ -100,7 +109,35 @@ export async function generateDiff(input: GenerateDiffInput): Promise<GenerateJs
     );
   }
 
-  const instructions = `Compare these two versions of a competitor page.
+  const rawCurrentContent = input.currentContent;
+  const hasCurrentContent = typeof rawCurrentContent === "string" && rawCurrentContent.length > 0;
+  const currentContent = hasCurrentContent
+    ? (rawCurrentContent as string).slice(0, MAX_CONTEXT_LENGTH)
+    : null;
+  if (hasCurrentContent && (rawCurrentContent as string).length > MAX_CONTEXT_LENGTH) {
+    process.emitWarning(
+      `[generateDiff] currentContent truncated from ${(rawCurrentContent as string).length} to ${MAX_CONTEXT_LENGTH} chars`,
+      { code: "RIVAL_CONTEXT_TRUNCATED" }
+    );
+  }
+
+  const instructions = currentContent
+    ? `Compare the two versions of a competitor page provided below.
+Base your diff ONLY on these two snapshots — do not rely on any live content
+that may be fetched alongside this request. Both snapshots were captured by
+this system; the "Current version" is the authoritative new state.
+
+List what was added, changed, or removed in plain English.
+Be concise. Focus on developer-facing changes. If the two versions are
+effectively identical (only whitespace, ordering, or boilerplate differs),
+return empty added/changed/removed lists and an empty summary.
+
+Previous version:
+${previousContent}
+
+Current version:
+${currentContent}`
+    : `Compare these two versions of a competitor page.
 List what was added, changed, or removed in plain English.
 Be concise. Focus on developer-facing changes.
 


### PR DESCRIPTION
## Problem
Every competitor's homepage (and any other page with a previous scan) is being flagged as "edited" on every scan. The new `/[slug]/history` UI exposed the issue but the root cause is older.

## Root cause — `generate.json` double-fetches
`lib/scanner.ts` calls `generateDiff()` with `url: input.url` and `previousContent: toPreviousContent(previousScan)`. Tabstack's `generate.json` **re-fetches** that URL server-side — so the diff LLM compares:

- **Previous**: the stored markdown from the last scan
- **"Current"**: a *fresh* fetch Tabstack just did — seconds after the primary scan, possibly a different render

Any dynamic element (rotating hero copy, timestamps, A/B variants, session tokens) produces a "changed" verdict on every run. This has likely been happening since the scanner was introduced; the new history page just makes it visible.

## Fix
Two complementary changes:

1. **Short-circuit on matching content** (`lib/scanner.ts`)
   After `runPrimaryScan`, normalize the previous and current markdowns (CRLF → LF, trim trailing whitespace, collapse extra blank lines) and compare as strings. When equal → skip the `generate.json` diff call entirely and persist the scan with `hasChanges=false`, `diffSummary=null`. Saves an LLM round-trip on every no-op scheduled scan.

2. **`currentContent` passthrough** (`lib/tabstack/generate.ts`)
   When content genuinely differs, pass the just-captured markdown as a new `currentContent` field on `GenerateDiffInput`. The prompt is rewritten to instruct the model to compare **only** the two provided snapshots, ignoring any live fetch that `generate.json` performs alongside the request. The original single-version prompt is preserved as a fallback when `currentContent` isn't supplied (backward compatible with any other caller).

## Tests
- New: short-circuits when previous and current markdown match (even with differing line endings / trailing whitespace) — asserts `generateDiff` is not called and the scan row stores `hasChanges=false, diffSummary=null`.
- New: when content genuinely differs, `generateDiff` is called with both `previousContent` and `currentContent`.
- All 357 existing tests pass; `npm run typecheck` clean.

## Test plan (post-merge)
- [ ] Trigger a manual scan of an unchanged competitor page; confirm `hasChanges=false` in DB and the history row shows "no change."
- [ ] Trigger a scan after making a real change; confirm diff summary still renders correctly.
- [ ] Check API logs — `generate` calls should drop noticeably after this ships (no-op scans no longer call it).

## Related
Separately tracked DX note in `notes-local/tabstack-dx-notes.md` (gitignored) on the `generate.json` re-fetch behavior for upstream SDK feedback.