### PR TITLE
feat: add refresh-briefs script for on-demand brief regeneration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "db:seed": "tsx scripts/seed.ts",
+    "refresh-briefs": "tsx scripts/refresh-briefs.ts",
     "validate:scan-cycle": "tsx scripts/validate-scan-cycle.ts"
   },
   "dependencies": {

--- a/scripts/refresh-briefs.ts
+++ b/scripts/refresh-briefs.ts
@@ -1,0 +1,85 @@
+/**
+ * Force-regenerate competitive intelligence briefs for every competitor.
+ *
+ * Why this exists: Competitor.threatLevel is a cached enum written by
+ * generateCompetitorBrief. Prompt changes (e.g. the rubric rewrite in PR #75)
+ * only take effect on the next brief run, which otherwise happens on the
+ * weekday cron schedule. This script triggers an immediate refresh — handy
+ * before a demo, after tuning the rubric, or when the dashboard looks stale.
+ *
+ * Usage:
+ *   DATABASE_URL=<prod-url> TABSTACK_API_KEY=<key> npm run refresh-briefs
+ *
+ * Safety:
+ *   - Runs briefs sequentially to stay polite to the Tabstack API.
+ *   - Requires at least one recent scan per competitor; logs and skips any
+ *     competitor that has none (brief generation throws in that case).
+ *   - Each brief costs one generate.json call. With 8 competitors this is
+ *     bounded cost — don't loop this script.
+ */
+
+import { generateCompetitorBrief } from "@/lib/brief";
+import { prisma } from "@/lib/db/client";
+
+type BriefOutcome =
+  | { slug: string; name: string; status: "updated"; before: string; after: string; reasoning: string }
+  | { slug: string; name: string; status: "skipped" | "error"; before: string; message: string };
+
+function formatRow(slug: string, before: string, after: string, detail: string): string {
+  return `${slug.padEnd(22)} ${before.padEnd(8)} → ${after.padEnd(8)} ${detail}`;
+}
+
+async function main() {
+  const competitors = await prisma.competitor.findMany({
+    select: { id: true, slug: true, name: true, threatLevel: true },
+    orderBy: { slug: "asc" }
+  });
+
+  if (competitors.length === 0) {
+    console.log("No competitors in DB. Run `npm run db:seed` first.");
+    return;
+  }
+
+  console.log(`Refreshing briefs for ${competitors.length} competitor${competitors.length === 1 ? "" : "s"}...\n`);
+  console.log(formatRow("slug", "before", "after", "reasoning"));
+  console.log("-".repeat(100));
+
+  const outcomes: BriefOutcome[] = [];
+
+  for (const competitor of competitors) {
+    const before = competitor.threatLevel ?? "—";
+    try {
+      const payload = await generateCompetitorBrief(competitor.id, true);
+      const threatRaw = (payload as { threat_level?: unknown })?.threat_level;
+      const reasoningRaw = (payload as { threat_reasoning?: unknown })?.threat_reasoning;
+      const after = typeof threatRaw === "string" ? threatRaw : "—";
+      const reasoning = typeof reasoningRaw === "string" ? reasoningRaw.slice(0, 80) : "";
+      console.log(formatRow(competitor.slug, before, after, reasoning));
+      outcomes.push({ slug: competitor.slug, name: competitor.name, status: "updated", before, after, reasoning });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status: "skipped" | "error" = message.includes("No recent scans") ? "skipped" : "error";
+      console.log(formatRow(competitor.slug, before, status === "skipped" ? "skip" : "ERR", message));
+      outcomes.push({ slug: competitor.slug, name: competitor.name, status, before, message });
+    }
+  }
+
+  const updated = outcomes.filter((o) => o.status === "updated").length;
+  const skipped = outcomes.filter((o) => o.status === "skipped").length;
+  const errored = outcomes.filter((o) => o.status === "error").length;
+
+  console.log(`\nDone: ${updated} updated, ${skipped} skipped (no recent scans), ${errored} errored.`);
+
+  if (errored > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
Adds `scripts/refresh-briefs.ts` and wires it as `npm run refresh-briefs`. The script iterates every competitor in the DB, calls `generateCompetitorBrief(id, nocache=true)` on each, and prints a before/after threat-level table plus the reasoning.

## Why now
`Competitor.threatLevel` is cached and only refreshes via the weekday cron (`0 9 * * 1-5`). After the rubric prompt change in PR #75, the dashboard is stuck showing the old all-"High" ratings until the next cron tick — which is awkward right before a demo. This script gives an explicit "refresh now" path.

## Usage
```bash
DATABASE_URL=<prod-url> TABSTACK_API_KEY=<key> npm run refresh-briefs
```

Same env contract as `scripts/seed.ts` — user pulls `DATABASE_URL` from Netlify and points the script at prod.

## Output example
```
slug                   before   → after    reasoning
----------------------------------------------------------------------------------------------------
apify                  High     → Medium   Partial audience overlap; no 30-day momentum signals.
browserbase            High     → High     Direct API overlap and recent pricing moves.
...
Done: 8 updated, 0 skipped (no recent scans), 0 errored.
```

## Safety
- Sequential (no concurrent fan-out to Tabstack).
- Skips competitors with no recent scans (brief generation throws `No recent scans available`).
- Exits non-zero if any competitor errored, so it's safe to wire into a future `npm run` chain.
- One `generate.json` call per competitor — bounded cost at 8 competitors.

## Test plan
- [ ] `npm run typecheck` clean (verified locally).
- [ ] Full test suite passes — 359/359 (verified locally).
- [ ] Run against prod DB before Thursday's demo; confirm the threat matrix spreads across High/Medium/Low.