### PR TITLE
hotfix(ui): move View History link to top-right of detail page

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -273,11 +273,15 @@ export default async function CompetitorDetailPage({ params }: PageProps) {
         <Link href="/" className="back-link">
           ← Dashboard
         </Link>
-        <h1>{competitor.name}</h1>
-        <p>{competitor.baseUrl}</p>
-        <Link href={`/${competitor.slug}/history`} className="tag-chip tag-chip--secondary">
-          View History
-        </Link>
+        <div className="page-header-row">
+          <div className="page-header-titles">
+            <h1>{competitor.name}</h1>
+            <p>{competitor.baseUrl}</p>
+          </div>
+          <Link href={`/${competitor.slug}/history`} className="tag-chip tag-chip--secondary page-header-action">
+            View History →
+          </Link>
+        </div>
       </header>
 
       <section className="panel">

--- a/app/globals.css
+++ b/app/globals.css
@@ -61,6 +61,26 @@ body {
   color: var(--text);
 }
 
+.page-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-header-titles {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.page-header-action {
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  white-space: nowrap;
+}
+
 .page-header h1 {
   margin: 0;
   font-size: clamp(1.75rem, 5vw, 2.75rem);


### PR DESCRIPTION
## Summary
The \`View History\` link was already in the header markup (added in 9b5f15e) but rendered as body text below the baseUrl, easy to miss. Move it to the top-right of the header so it reads as a clear secondary action.

## Change
- \`app/[slug]/page.tsx\`: wrap \`<h1>\` + baseUrl and the history link in a flex row; link gets a \`page-header-action\` class and an arrow affordance (\`View History →\`).
- \`app/globals.css\`: \`.page-header-row\` uses flex \`space-between\`, \`flex-wrap: wrap\` so the link drops below the title on narrow viewports rather than overlapping.

## Before / After
Before: title, baseUrl, then "View History" stacked vertically, all left-aligned.
After: title + baseUrl top-left, "View History →" chip top-right of the header.

## Notes
- CSS-only + markup restructure — no data or behavior changes.
- \`npm run typecheck\` clean; 359 tests pass; prettier clean.
- Did **not** verify in a live browser locally (no dev DB set up). Flex layout is standard enough that the Netlify deploy-preview should confirm visually.

## Test plan
- [ ] Deploy preview: visit any competitor detail page; confirm "View History →" sits top-right of the header and links to \`/[slug]/history\`.
- [ ] Resize to narrow viewport (≤500px); confirm link wraps below title instead of overlapping.
- [ ] Mobile tap target is reasonable.