### PR TITLE
fix(brief): tighten threat rubric — High reserved for commercial competitors

### DIFF
--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -252,13 +252,23 @@ produce a structured brief covering:
 2. Content opportunity — what topics should you own based on their blind spots?
 3. Product opportunity — what are developers complaining about that you could solve?
 4. Threat level — rate as High, Medium, or Low using this rubric, with one sentence of reasoning:
-   - High: Direct feature AND audience overlap, AND active momentum in the last ~30 days
-     (recent launches, relevant hiring, pricing moves, or notable GitHub/community growth).
-   - Medium: Partial overlap (audience OR use case, not both), OR full overlap with stalled
-     execution (no recent shipping, hiring, or pricing activity).
+   - High: A direct commercial competitor — a paid, managed, or hosted product — with
+     clear feature AND audience overlap AND active momentum in the last ~30 days
+     (launches, relevant hiring, pricing moves, or notable paying-customer / growth signals).
+   - Medium: (a) an open-source library, SDK, or framework that competes for mindshare
+     but not revenue; (b) a commercial competitor with stalled execution (no recent
+     shipping, hiring, or pricing activity); OR (c) partial overlap — audience OR use
+     case, but not both.
    - Low: Adjacent space, different ICP, or clear wind-down signals.
-   Reserve High for competitors with BOTH overlap AND momentum. When evidence is mixed,
-   sparse, or ambiguous, default to Medium rather than High.
+   Important distinctions:
+   - Open-source libraries, SDKs, and generic frameworks are Medium at most, even if
+     widely adopted. They represent "build it yourself" alternatives that can often be
+     composed with our product rather than replacing it. Stars or downloads alone do
+     not make something a High-threat competitor.
+   - Reserve High for commercial, managed, paid products with BOTH real commercial
+     overlap AND recent momentum. If the competitor does not sell a hosted product or
+     paid service, it should not be High.
+   - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
 5. Watch list: 2-3 signals to monitor next cycle
 Be direct and specific. No generic advice.
 

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -252,22 +252,26 @@ produce a structured brief covering:
 2. Content opportunity — what topics should you own based on their blind spots?
 3. Product opportunity — what are developers complaining about that you could solve?
 4. Threat level — rate as High, Medium, or Low using this rubric, with one sentence of reasoning:
-   - High: A direct commercial competitor — a paid, managed, or hosted product — with
+   - High: A direct commercial competitor — a paid, managed, or hosted offering — with
      clear feature AND audience overlap AND active momentum in the last ~30 days
      (launches, relevant hiring, pricing moves, or notable paying-customer / growth signals).
-   - Medium: (a) an open-source library, SDK, or framework that competes for mindshare
-     but not revenue; (b) a commercial competitor with stalled execution (no recent
-     shipping, hiring, or pricing activity); OR (c) partial overlap — audience OR use
-     case, but not both.
+   - Medium: (a) a pure open-source project (library, SDK, or framework) with NO paid
+     or managed counterpart; (b) a commercial competitor with stalled execution (no
+     recent shipping, hiring, or pricing activity); OR (c) partial overlap — audience
+     OR use case, but not both.
    - Low: Adjacent space, different ICP, or clear wind-down signals.
    Important distinctions:
-   - Open-source libraries, SDKs, and generic frameworks are Medium at most, even if
-     widely adopted. They represent "build it yourself" alternatives that can often be
-     composed with our product rather than replacing it. Stars or downloads alone do
-     not make something a High-threat competitor.
-   - Reserve High for commercial, managed, paid products with BOTH real commercial
-     overlap AND recent momentum. If the competitor does not sell a hosted product or
-     paid service, it should not be High.
+   - Rate a competitor on what they actually sell, not on whether they publish source
+     code. Many companies ship an open-source project alongside a paid product
+     (open-core). Judge them on the paid offering, not the repo — an open-core
+     company running a managed cloud or paid service is rated like any other
+     commercial competitor, and if overlap + momentum are present, they are High.
+     Do NOT anchor on "Medium at most" just because the codebase is open-source.
+   - A pure library / framework / SDK with no paid offering is Medium at most,
+     regardless of stars or downloads. Popularity alone is not a High threat because
+     it does not compete for our revenue.
+   - Reserve High for offerings that directly compete for our revenue, not for
+     mindshare or developer adoption alone.
    - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
 5. Watch list: 2-3 signals to monitor next cycle
 Be direct and specific. No generic advice.


### PR DESCRIPTION
## Context
PR #75 added a rubric and anchor for the threat level. After running \`npm run refresh-briefs\` against prod with the new rubric, every rated competitor still came back **High** — because the model was (correctly) reading "feature + audience overlap + momentum" and applying it to OSS libraries like Playwright, framework tools like LangChain, and OSS wrappers like Stagehand. None of those are **commercial** threats to a paid managed service.

## Change
Encode the commercial-vs-OSS distinction explicitly in the prompt:

- **High now requires a paid / managed / hosted product** with BOTH commercial overlap AND recent momentum.
- **OSS libraries, SDKs, and generic frameworks are Medium at most** — regardless of stars or downloads, they compete for mindshare, not revenue, and can often be composed with the product rather than replace it.
- **Medium** also still covers partial overlap or stalled commercial execution.
- The "default to Medium when mixed/ambiguous" anchor from PR #75 is preserved.

Only the free-text \`instructions\` in \`generateBrief\` change — schema, field names, storage, and downstream rendering are unchanged.

## Expected distribution after re-running \`npm run refresh-briefs\`
Rough prediction based on what each competitor actually is:
- **High**: Browserbase, Browser-use, Firecrawl, Steel, Apify — all paid managed services with active shipping.
- **Medium**: Playwright (OSS library), LangChain Browser Tools (framework), Stagehand (Browserbase's OSS wrapper).

Obvious failure mode: everything flips to Medium. If that happens the High criteria probably need tightening back up slightly. We'll see after a live run.

## Verification
- \`npm run typecheck\` — clean.
- \`npx vitest run lib/tabstack/__tests__/generate.test.ts lib/__tests__/brief.test.ts\` — 36/36 pass.
- Prettier clean.

## Test plan (post-merge)
- [ ] Run \`DATABASE_URL=<prod> TABSTACK_API_KEY=<key> npm run refresh-briefs\`; confirm Playwright / LangChain / Stagehand drop to Medium.
- [ ] Spot-check reasoning strings for the newly-Medium competitors; they should reference OSS/library/framework.
- [ ] If any High-rated competitor drops incorrectly, tighten only the High criteria (not the OSS-excluded line).