### PR TITLE
feat: auto-bootstrap new competitors on production deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,16 +3,24 @@
   publish = ".next"
   functions = "netlify/functions"
 
-# Seed is production-only.
+# Seed + bootstrap are production-only.
 #
 # The [build] block above applies to every Netlify context (production,
-# deploy-preview, branch-deploy). Seeding during a preview build would
-# upsert competitor and page rows against whatever DATABASE_URL that
-# context has — which, if shared with production, means any PR build
-# could mutate live data. Scope seeding to the production context so
-# previews stay read-only.
+# deploy-preview, branch-deploy). Writing to the DB during a preview build
+# would mutate whatever DATABASE_URL that context has — which, if shared
+# with production, means any PR build could touch live data. Scope DB
+# writes to the production context so previews stay read-only.
+#
+# Order matters:
+# 1. prisma generate — regenerates the client against the current schema.
+# 2. npm run build — Next.js production build.
+# 3. scripts/seed.ts — reconciles Competitor / CompetitorPage rows with
+#    rivals.config.json (idempotent upsert by slug).
+# 4. scripts/bootstrap-new-competitors.ts — runs a first scan cycle plus
+#    brief for any competitor that still has zero scans. Idempotent, and
+#    non-fatal by design so a Tabstack hiccup never blocks a deploy.
 [context.production]
-  command = "npx prisma generate && npm run build && npx tsx scripts/seed.ts"
+  command = "npx prisma generate && npm run build && npx tsx scripts/seed.ts && npx tsx scripts/bootstrap-new-competitors.ts"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "db:seed": "tsx scripts/seed.ts",
+    "bootstrap-new": "tsx scripts/bootstrap-new-competitors.ts",
     "refresh-briefs": "tsx scripts/refresh-briefs.ts",
     "validate:scan-cycle": "tsx scripts/validate-scan-cycle.ts"
   },

--- a/scripts/bootstrap-new-competitors.ts
+++ b/scripts/bootstrap-new-competitors.ts
@@ -1,0 +1,126 @@
+/**
+ * Bootstrap a first scan cycle for any competitor with zero scans.
+ *
+ * Why this exists: rivals.config.json + scripts/seed.ts create the Competitor
+ * and CompetitorPage rows, but scans only run on the weekday cron. A freshly
+ * added competitor therefore has no data on the dashboard until the next cron
+ * tick — up to ~24 hours. Rival exists to showcase Tabstack, so a new
+ * competitor should come online immediately.
+ *
+ * What it does:
+ * - Lists every Competitor.
+ * - Skips any competitor that already has at least one Scan row.
+ * - For the rest, scans each CompetitorPage sequentially and then generates
+ *   the intelligence brief.
+ *
+ * Design notes:
+ * - Idempotent: re-running it is a no-op when every competitor has scans.
+ * - Sequential per-page + sequential per-competitor to stay polite to the
+ *   Tabstack API and keep output readable in build logs.
+ * - Non-fatal: individual scan or brief errors are logged but do not abort
+ *   the loop. The script exits 0 even when some pages fail, so wiring it
+ *   into a production build (see netlify.toml) never blocks a deploy.
+ *
+ * Usage:
+ *   npm run bootstrap-new
+ *
+ * Runs automatically as part of the Netlify production build, after seed.
+ */
+
+import { generateCompetitorBrief } from "@/lib/brief";
+import { prisma } from "@/lib/db/client";
+import { scanPage } from "@/lib/scanner";
+
+async function bootstrapCompetitor(competitor: {
+  id: string;
+  slug: string;
+  name: string;
+  pages: Array<{ id: string; label: string; url: string; type: string; geoTarget: string | null }>;
+}) {
+  console.log(`\n[bootstrap] ${competitor.slug}: scanning ${competitor.pages.length} page(s)...`);
+  let scanErrors = 0;
+
+  for (const page of competitor.pages) {
+    try {
+      const result = await scanPage({
+        competitorId: competitor.id,
+        pageId: page.id,
+        label: page.label,
+        url: page.url,
+        type: page.type,
+        geoTarget: page.geoTarget
+      });
+      console.log(`  ✓ ${page.type.padEnd(10)} ${page.label.padEnd(20)} endpoint=${result.endpointUsed}`);
+    } catch (error) {
+      scanErrors += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`  ✗ ${page.type.padEnd(10)} ${page.label.padEnd(20)} ${message}`);
+    }
+  }
+
+  // Only attempt a brief if at least one scan landed — generateCompetitorBrief
+  // throws when there are no recent scans for the competitor, which would be
+  // noisy in build logs.
+  const scanCount = await prisma.scan.count({ where: { page: { competitorId: competitor.id } } });
+  if (scanCount === 0) {
+    console.warn(`[bootstrap] ${competitor.slug}: no scans landed, skipping brief generation.`);
+    return;
+  }
+
+  console.log(`[bootstrap] ${competitor.slug}: generating brief...`);
+  try {
+    const payload = await generateCompetitorBrief(competitor.id, true);
+    const threat = (payload as { threat_level?: string })?.threat_level ?? "—";
+    console.log(`[bootstrap] ${competitor.slug}: brief generated (threat=${threat}, scan errors=${scanErrors}).`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[bootstrap] ${competitor.slug}: brief failed: ${message}`);
+  }
+}
+
+async function main() {
+  const competitors = await prisma.competitor.findMany({
+    include: { pages: true },
+    orderBy: { slug: "asc" }
+  });
+
+  if (competitors.length === 0) {
+    console.log("[bootstrap] No competitors in DB. Run `npm run db:seed` first.");
+    return;
+  }
+
+  // Fetch the set of competitorIds that already have scans. Faster than
+  // per-competitor checks, and cheaper than a join.
+  const scanned = await prisma.scan.findMany({
+    distinct: ["pageId"],
+    select: { page: { select: { competitorId: true } } }
+  });
+  const scannedCompetitorIds = new Set(scanned.map((s) => s.page.competitorId));
+
+  const toBootstrap = competitors.filter((c) => !scannedCompetitorIds.has(c.id));
+
+  if (toBootstrap.length === 0) {
+    console.log(`[bootstrap] All ${competitors.length} competitor(s) already have scans. Nothing to do.`);
+    return;
+  }
+
+  console.log(
+    `[bootstrap] Found ${toBootstrap.length} unscanned competitor(s): ${toBootstrap.map((c) => c.slug).join(", ")}`
+  );
+
+  for (const competitor of toBootstrap) {
+    await bootstrapCompetitor(competitor);
+  }
+
+  console.log(`\n[bootstrap] Done.`);
+}
+
+main()
+  .catch((error) => {
+    // Non-fatal by design: log and exit 0 so a bootstrap hiccup never blocks
+    // a production deploy. Errors surface in the Netlify build log.
+    console.error("[bootstrap] unexpected error:", error);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/bootstrap-new-competitors.ts
+++ b/scripts/bootstrap-new-competitors.ts
@@ -109,6 +109,21 @@ async function main() {
   );
 
   for (const competitor of toBootstrap) {
+    // Re-check immediately before bootstrapping. The snapshot above can go
+    // stale if a concurrent cron run or a parallel deploy writes the first
+    // scan between now and this loop iteration — without this check, two
+    // near-simultaneous production builds could both bootstrap the same
+    // competitor and double-write scans + briefs. This shrinks the race
+    // window from "seconds" to "the gap between the count and the first
+    // scanPage call." It is not atomic; for a true lock a DB-level
+    // bootstrap-runs table or advisory lock would be needed.
+    const freshScanCount = await prisma.scan.count({
+      where: { page: { competitorId: competitor.id } }
+    });
+    if (freshScanCount > 0) {
+      console.log(`[bootstrap] ${competitor.slug}: scans now exist (likely concurrent run), skipping.`);
+      continue;
+    }
     await bootstrapCompetitor(competitor);
   }
 


### PR DESCRIPTION
## Problem
Adding a competitor to \`rivals.config.json\` was a two-step wait:
1. Production deploy seeds the \`Competitor\` / \`CompetitorPage\` rows.
2. …no scans until the weekday cron ticks — up to ~24 hours.

Apify (PR #73) just lived through this exact scenario: the dashboard knew about it but had nothing to show. Rival exists to demonstrate Tabstack end-to-end, so a new competitor should come online immediately.

## Fix
Add \`scripts/bootstrap-new-competitors.ts\` and wire it into the production Netlify build, after seed.

**Behavior**
- Lists every Competitor in the DB.
- Skips any competitor that already has at least one \`Scan\` row (idempotent — re-running is a no-op).
- For the unscanned ones, calls \`scanPage\` on each \`CompetitorPage\` sequentially, then \`generateCompetitorBrief\`.
- **Non-fatal**: individual scan / brief errors are logged but do not abort the loop. The script always exits 0, so a Tabstack hiccup never blocks a deploy.

**Netlify build command (production context only)**
\`\`\`
npx prisma generate && npm run build && npx tsx scripts/seed.ts && npx tsx scripts/bootstrap-new-competitors.ts
\`\`\`

Preview / branch-deploy builds stay read-only (base \`[build]\` command unchanged).

## Why sequential, not parallel
- Stays polite to the Tabstack API (no sudden fan-out on deploy).
- Keeps build logs readable line by line.
- Build-time cost is bounded by how many unscanned competitors exist at deploy time — usually 0, occasionally 1-2.

## Why non-fatal
A production build should not fail because Tabstack returned a transient 500 on one page. Any failed scans or briefs show up in the build log and will be retried by the next cron cycle anyway.

## Test plan (post-merge)
- [ ] First deploy after merge: Apify already has scans, so bootstrap logs \"All 8 competitor(s) already have scans. Nothing to do.\" and finishes in <1s.
- [ ] Open a follow-up PR that adds a new competitor; after the production merge, verify build log shows bootstrap scanning it and generating a brief.
- [ ] Dashboard shows the new competitor with data on first visit (no 24-hour gap).

## Verification
- \`npm run typecheck\` — clean.
- Full test suite — 359/359 pass.