### PR TITLE
fix(brief): add revenue-question anchor; corporate backing ≠ paid offering

### DIFF
--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -260,17 +260,24 @@ produce a structured brief covering:
      recent shipping, hiring, or pricing activity); OR (c) partial overlap — audience
      OR use case, but not both.
    - Low: Adjacent space, different ICP, or clear wind-down signals.
-   Important distinctions:
-   - Rate a competitor on what they actually sell, not on whether they publish source
-     code. Many companies ship an open-source project alongside a paid product
-     (open-core). Judge them on the paid offering, not the repo — an open-core
-     company running a managed cloud or paid service is rated like any other
-     commercial competitor, and if overlap + momentum are present, they are High.
-     Do NOT anchor on "Medium at most" just because the codebase is open-source.
-   - A pure library / framework / SDK with no paid offering is Medium at most,
-     regardless of stars or downloads. Popularity alone is not a High threat because
-     it does not compete for our revenue.
-   - Reserve High for offerings that directly compete for our revenue, not for
+   Important distinctions — apply in order:
+   - FIRST ask the revenue question: can a customer buy this specific product
+     today — with a credit card, a sales contract, or a managed/hosted SKU? If
+     NO, the threat is Medium at most, full stop. Corporate backing alone does
+     NOT count: a large company maintaining an open-source project as a
+     community investment, without selling a paid or managed version of it,
+     still fails the revenue question. Momentum, stars, downloads, corporate
+     sponsorship, and "widely used in industry" are not substitutes for a paid
+     offering.
+   - If the revenue answer is YES, then rate on what they actually sell. Many
+     companies ship an open-source project alongside a paid product (open-core).
+     Judge them on the paid offering, not the repo — an open-core company
+     running a managed cloud or paid service is rated like any other commercial
+     competitor, and if overlap + momentum are present, they are High. Do NOT
+     anchor on "Medium at most" just because the codebase is open-source.
+   - A pure library / framework / SDK with no paid counterpart is Medium at
+     most, regardless of stars, downloads, or corporate backing.
+   - Reserve High for offerings that directly compete for our REVENUE, not for
      mindshare or developer adoption alone.
    - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
 5. Watch list: 2-3 signals to monitor next cycle


### PR DESCRIPTION
## Context
After PR #79 merged and I ran \`npm run refresh-briefs\` against prod:
- **Stagehand** correctly dropped to Medium (pure OSS, no paid counterpart — exactly what the rubric intended).
- **Playwright** stayed at **High**, with reasoning citing "Microsoft backing." Playwright is a pure OSS framework with no paid Playwright product — it should be Medium.

So the rubric wasn't handling the "corporate-backed OSS" case: the model reads "Microsoft backs it" as a commercial signal, even though Microsoft doesn't sell Playwright.

## Change
Add an explicit "revenue question" as the **first** step of the rubric:

> Can a customer buy this specific product today — with a credit card, a sales contract, or a managed/hosted SKU? If NO, the threat is Medium at most, full stop.

Then call out the edge case directly: **corporate backing alone does not count**. A large company maintaining an OSS project as a community investment, without selling a paid version of it, still fails the revenue question.

Structured as "apply in order" bullets so the revenue check runs **before** the open-core exception (which PR #79 added and this PR preserves intact). An open-core company that sells a paid product still passes the revenue question and gets rated on that product as before — this change does NOT reintroduce "Medium at most" anchoring for open-core.

## Expected effect after merging + \`npm run refresh-briefs\`
- **Playwright → Medium**: fails revenue question (no paid Playwright product).
- **LangChain → stays High** (or possibly moves): LangSmith IS a paid product, but the model's previous reasoning for LangChain could have been about the OSS framework itself; the revenue question should clarify.
- Rest unchanged.

## Verification
- \`npm run typecheck\` — clean.
- \`npx vitest run lib/tabstack/__tests__/generate.test.ts lib/__tests__/brief.test.ts\` — 36/36 pass.
- Prettier clean.

## Test plan (post-merge)
- [ ] Re-run \`npm run refresh-briefs\`.
- [ ] Confirm Playwright drops to Medium with reasoning that references the revenue question, not "Microsoft backing."
- [ ] Confirm open-core competitors (Firecrawl, LangChain via LangSmith) still read as High.
- [ ] Watch for overcorrection: if anything commercial drops to Medium, the revenue-question wording may need softening.