### PR TITLE
feat(dashboard): bound Intel Feed to last 7 days

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,11 @@ import type { ReviewsData } from "@/lib/schemas/reviews";
 
 export const dynamic = "force-dynamic";
 
+// How far back the Intel Feed looks for changed scans. Changes older than
+// this are "history," not "intel." Keep in sync with the window the UI
+// labels use if you surface it there.
+const INTEL_FEED_WINDOW_DAYS = 7;
+
 function computeReviewsEvents(
   current: ReviewsData,
   previous: ReviewsData | null
@@ -105,8 +110,16 @@ async function loadDashboardData() {
   });
 
   // Fetch changed scans for the Intel Feed, including rawResult for reviews diff events.
+  // Bounded to INTEL_FEED_WINDOW_DAYS so stale changes don't linger on the dashboard —
+  // a "change" from three weeks ago is not useful competitive intel, and the window
+  // also prevents legacy false-positive rows (pre-scanner-fix) from clogging the feed
+  // until they age out naturally.
+  const feedCutoff = new Date(Date.now() - INTEL_FEED_WINDOW_DAYS * 24 * 60 * 60 * 1000);
   const feed = await prisma.scan.findMany({
-    where: { hasChanges: true },
+    where: {
+      hasChanges: true,
+      scannedAt: { gte: feedCutoff }
+    },
     include: {
       page: true
     },


### PR DESCRIPTION
## Context
The Intel Feed on the dashboard was pulling the 25 most recent scans with \`hasChanges=true\` — no time bound. Two problems surfaced today:

1. **Product**: a "change" from three weeks ago is not competitive intel. Stale diffs dilute the signal.
2. **Operational**: when the scanner double-fetch bug (fixed in PR #76) wrote ~40 legacy false-positive homepage rows, they dominated the feed and would keep dominating until enough new legitimate changes pushed them out. With cron running only weekdays 9 UTC, the feed could stay junk-heavy for days.

(Separately, those 42 legacy rows were cleaned up in the DB with a one-off reversible data-fix script. This PR is the durable side of the fix.)

## Change
- Add \`INTEL_FEED_WINDOW_DAYS = 7\` constant at the top of \`app/page.tsx\`.
- Add \`scannedAt: { gte: now - window }\` to the feed query.
- Everything else (sort, \`take: 25\`, downstream homepage/reviews follow-up queries) unchanged — the follow-ups derive from the bounded \`feed\` array and inherit the filter.

## Why 7 days
A week covers the typical "did something change since our last standup / prep cycle" question. Easy to revisit if it proves too short (e.g., quiet competitors).

## Verification
- \`npm run typecheck\` — clean.
- 359/359 tests pass.
- Prettier clean.

## Test plan (post-merge)
- [ ] Dashboard Intel Feed shows only scans from the last 7 days.
- [ ] After next cron tick, new legitimate changes appear.
- [ ] Old homepage false-positives that have already been data-cleaned stay out of the feed (double protection).