### PR TITLE
feat: self-profile for personalized competitive context

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -293,7 +293,7 @@ export default async function CompetitorDetailPage({ params }: PageProps) {
         typeof competitor.intelligenceBrief === "object" &&
         !Array.isArray(competitor.intelligenceBrief) ? (
           competitor.isSelf ? (
-            <SelfBriefView brief={competitor.intelligenceBrief as never} />
+            <SelfBriefView brief={competitor.intelligenceBrief as Record<string, unknown>} />
           ) : (
             (() => {
               const brief = competitor.intelligenceBrief as Record<string, unknown>;

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { SchemaHealthBadge } from "@/components/competitor/SchemaHealthBadge";
+import { SelfBriefView } from "@/components/brief/SelfBriefView";
 import { LogsTable } from "@/components/logs/LogsTable";
 import { prisma } from "@/lib/db/client";
 import type { BlogData } from "@/lib/schemas/blog";
@@ -286,49 +287,53 @@ export default async function CompetitorDetailPage({ params }: PageProps) {
 
       <section className="panel">
         <header className="panel-header">
-          <h2>Intelligence Brief</h2>
+          <h2>{competitor.isSelf ? "Your Profile" : "Intelligence Brief"}</h2>
         </header>
         {competitor.intelligenceBrief &&
         typeof competitor.intelligenceBrief === "object" &&
         !Array.isArray(competitor.intelligenceBrief) ? (
-          (() => {
-            const brief = competitor.intelligenceBrief as Record<string, unknown>;
-            const threatLevel = typeof brief["threat_level"] === "string" ? brief["threat_level"] : null;
-            return (
-              <div className="brief-body">
-                {threatLevel && (
-                  <div className="brief-threat-row">
-                    <span className={`brief-threat-badge brief-threat--${threatLevel.toLowerCase()}`}>
-                      {threatLevel} Threat
-                    </span>
-                    {typeof brief["threat_reasoning"] === "string" && (
-                      <p className="brief-threat-reasoning">{brief["threat_reasoning"]}</p>
-                    )}
-                  </div>
-                )}
-                {(["positioning_opportunity", "content_opportunity", "product_opportunity"] as const).map((key) =>
-                  typeof brief[key] === "string" ? (
-                    <div key={key} className="brief-section">
-                      <h3 className="brief-section-label">{key.replace(/_/g, " ")}</h3>
-                      <p>{brief[key] as string}</p>
-                    </div>
-                  ) : null
-                )}
-                {Array.isArray(brief["watch_list"]) && brief["watch_list"].length > 0 && (
-                  <div className="brief-section">
-                    <h3 className="brief-section-label">Watch List</h3>
-                    <ul className="brief-watch-list">
-                      {(brief["watch_list"] as unknown[]).map((item, i) =>
-                        typeof item === "string" ? <li key={i}>{item}</li> : null
+          competitor.isSelf ? (
+            <SelfBriefView brief={competitor.intelligenceBrief as never} />
+          ) : (
+            (() => {
+              const brief = competitor.intelligenceBrief as Record<string, unknown>;
+              const threatLevel = typeof brief["threat_level"] === "string" ? brief["threat_level"] : null;
+              return (
+                <div className="brief-body">
+                  {threatLevel && (
+                    <div className="brief-threat-row">
+                      <span className={`brief-threat-badge brief-threat--${threatLevel.toLowerCase()}`}>
+                        {threatLevel} Threat
+                      </span>
+                      {typeof brief["threat_reasoning"] === "string" && (
+                        <p className="brief-threat-reasoning">{brief["threat_reasoning"]}</p>
                       )}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            );
-          })()
+                    </div>
+                  )}
+                  {(["positioning_opportunity", "content_opportunity", "product_opportunity"] as const).map((key) =>
+                    typeof brief[key] === "string" ? (
+                      <div key={key} className="brief-section">
+                        <h3 className="brief-section-label">{key.replace(/_/g, " ")}</h3>
+                        <p>{brief[key] as string}</p>
+                      </div>
+                    ) : null
+                  )}
+                  {Array.isArray(brief["watch_list"]) && brief["watch_list"].length > 0 && (
+                    <div className="brief-section">
+                      <h3 className="brief-section-label">Watch List</h3>
+                      <ul className="brief-watch-list">
+                        {(brief["watch_list"] as unknown[]).map((item, i) =>
+                          typeof item === "string" ? <li key={i}>{item}</li> : null
+                        )}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              );
+            })()
+          )
         ) : (
-          <p className="muted">No brief generated yet.</p>
+          <p className="muted">{competitor.isSelf ? "Self-profile not yet generated." : "No brief generated yet."}</p>
         )}
       </section>
 

--- a/app/api/deep-dive/route.ts
+++ b/app/api/deep-dive/route.ts
@@ -69,7 +69,8 @@ export async function POST(request: NextRequest) {
           competitorId: competitor.id,
           query,
           mode,
-          nocache: true
+          nocache: true,
+          isDemo: false
         });
 
         for (const event of result.events) {

--- a/app/api/self/__tests__/route.test.ts
+++ b/app/api/self/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getSelfCompetitorMock, hasValidInternalApiKeyMock, isSameOriginRequestMock } = vi.hoisted(() => ({
+  getSelfCompetitorMock: vi.fn(),
+  hasValidInternalApiKeyMock: vi.fn(),
+  isSameOriginRequestMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/competitors", () => ({
+  getSelfCompetitor: getSelfCompetitorMock
+}));
+
+vi.mock("@/app/api/_lib/auth", () => ({
+  hasValidInternalApiKey: hasValidInternalApiKeyMock,
+  isSameOriginRequest: isSameOriginRequestMock
+}));
+
+describe("GET /api/self", () => {
+  beforeEach(() => {
+    getSelfCompetitorMock.mockReset();
+    hasValidInternalApiKeyMock.mockReset();
+    isSameOriginRequestMock.mockReset();
+  });
+
+  it("returns 403 when neither internal key nor same origin", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(false);
+    isSameOriginRequestMock.mockReturnValue(false);
+    const { GET } = await import("@/app/api/self/route");
+    const req = new NextRequest("http://localhost/api/self");
+    const response = await GET(req);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("returns 200 with self payload when same-origin request and self row exists", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(false);
+    isSameOriginRequestMock.mockReturnValue(true);
+    getSelfCompetitorMock.mockResolvedValue({ id: "self_1", name: "Rival", slug: "rival", isSelf: true, pages: [] });
+    const { GET } = await import("@/app/api/self/route");
+    const req = new NextRequest("http://localhost/api/self");
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.self?.name).toBe("Rival");
+    expect(body.self?.isSelf).toBe(true);
+  });
+
+  it("returns 200 with self: null when no self row exists", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(true);
+    isSameOriginRequestMock.mockReturnValue(false);
+    getSelfCompetitorMock.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/self/route");
+    const req = new NextRequest("http://localhost/api/self");
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.self).toBeNull();
+  });
+
+  it("returns 500 when the DB query throws", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(true);
+    isSameOriginRequestMock.mockReturnValue(false);
+    getSelfCompetitorMock.mockRejectedValue(new Error("db down"));
+    const { GET } = await import("@/app/api/self/route");
+    const req = new NextRequest("http://localhost/api/self");
+    const response = await GET(req);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toMatch(/db down/);
+  });
+});

--- a/app/api/self/route.ts
+++ b/app/api/self/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { hasValidInternalApiKey, isSameOriginRequest } from "@/app/api/_lib/auth";
+import { getSelfCompetitor } from "@/lib/db/competitors";
+
+export async function GET(request: NextRequest) {
+  if (!hasValidInternalApiKey(request) && !isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const self = await getSelfCompetitor();
+    return NextResponse.json({ self });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load self profile";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1116,3 +1116,25 @@ body {
   text-align: center;
   padding: 3rem 0;
 }
+
+/* ── Self Profile Card ───────────────────────────────────────────────── */
+
+.self-profile-card {
+  margin-bottom: 1.5rem;
+}
+.self-profile-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+.self-profile-card__eyebrow {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+}
+.self-profile-card__empty {
+  margin: 0;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1123,8 +1123,8 @@ body {
   margin-bottom: 1.5rem;
 }
 .self-profile-card__header {
-  display: flex;
-  justify-content: space-between;
+  /* .panel-header already provides display:flex + justify-content:space-between;
+     only the cross-axis alignment needs to change for the eyebrow + title stack. */
   align-items: flex-start;
 }
 .self-profile-card__eyebrow {
@@ -1137,4 +1137,8 @@ body {
 }
 .self-profile-card__empty {
   margin: 0;
+}
+.self-brief {
+  display: grid;
+  gap: 1rem;
 }

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -27,6 +27,7 @@ export default async function InsightsPage({ searchParams }: InsightsPageProps) 
   const params = await searchParams;
   const [competitors, endpointRows] = await Promise.all([
     prisma.competitor.findMany({
+      where: { isSelf: false },
       orderBy: { name: "asc" },
       select: { id: true, name: true }
     }),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,7 +122,8 @@ async function loadDashboardData() {
   const feed = await prisma.scan.findMany({
     where: {
       hasChanges: true,
-      scannedAt: { gte: feedCutoff }
+      scannedAt: { gte: feedCutoff },
+      page: { competitorId: { in: competitorIds } }
     },
     include: {
       page: true

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import { IntelFeed } from "@/components/dashboard/IntelFeed";
+import { SelfProfileCard } from "@/components/dashboard/SelfProfileCard";
 import { ThreatMatrix } from "@/components/dashboard/ThreatMatrix";
 import { prisma } from "@/lib/db/client";
+import { getSelfCompetitor } from "@/lib/db/competitors";
 import type { ReviewsData } from "@/lib/schemas/reviews";
 
 export const dynamic = "force-dynamic";
@@ -52,7 +54,7 @@ async function loadDashboardData() {
   });
   const competitorIds = competitors.map((competitor) => competitor.id);
 
-  const [recentScans, recentLogs] = await Promise.all([
+  const [recentScans, recentLogs, self] = await Promise.all([
     prisma.scan.findMany({
       where: { page: { competitorId: { in: competitorIds } } },
       select: {
@@ -74,7 +76,8 @@ async function loadDashboardData() {
       },
       orderBy: { calledAt: "desc" },
       take: 5000
-    })
+    }),
+    getSelfCompetitor()
   ]);
 
   const latestScanByCompetitor = new Map<string, Date>();
@@ -161,6 +164,7 @@ async function loadDashboardData() {
   }
 
   return {
+    self,
     matrix,
     feed: feed.map((item) => {
       const isReviews = item.page.type === "reviews";
@@ -197,6 +201,7 @@ export default async function HomePage() {
         <p>Threat posture, schema quality, and fresh competitor movement.</p>
       </header>
 
+      {data.self && <SelfProfileCard self={data.self} />}
       <ThreatMatrix competitors={data.matrix} />
       <IntelFeed items={data.feed} />
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,6 +47,7 @@ function computeReviewsEvents(
 
 async function loadDashboardData() {
   const competitors = await prisma.competitor.findMany({
+    where: { isSelf: false },
     orderBy: { name: "asc" }
   });
   const competitorIds = competitors.map((competitor) => competitor.id);

--- a/components/brief/SelfBriefView.tsx
+++ b/components/brief/SelfBriefView.tsx
@@ -1,0 +1,60 @@
+type SelfBrief = {
+  positioning_summary?: string;
+  icp_summary?: string;
+  pricing_summary?: string;
+  differentiators?: unknown;
+  recent_signals?: unknown;
+};
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+export function SelfBriefView({ brief }: { brief: SelfBrief }) {
+  const differentiators = asStringArray(brief.differentiators);
+  const recentSignals = asStringArray(brief.recent_signals);
+
+  return (
+    <div className="self-brief">
+      {brief.positioning_summary && (
+        <section className="brief-section">
+          <h3 className="brief-section-label">Positioning</h3>
+          <p>{brief.positioning_summary}</p>
+        </section>
+      )}
+      {brief.icp_summary && (
+        <section className="brief-section">
+          <h3 className="brief-section-label">ICP</h3>
+          <p>{brief.icp_summary}</p>
+        </section>
+      )}
+      {brief.pricing_summary && (
+        <section className="brief-section">
+          <h3 className="brief-section-label">Pricing</h3>
+          <p>{brief.pricing_summary}</p>
+        </section>
+      )}
+      {differentiators.length > 0 && (
+        <section className="brief-section">
+          <h3 className="brief-section-label">Differentiators</h3>
+          <ul className="brief-watch-list">
+            {differentiators.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {recentSignals.length > 0 && (
+        <section className="brief-section">
+          <h3 className="brief-section-label">Recent Signals</h3>
+          <ul className="brief-watch-list">
+            {recentSignals.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/components/brief/SelfBriefView.tsx
+++ b/components/brief/SelfBriefView.tsx
@@ -1,38 +1,40 @@
-type SelfBrief = {
-  positioning_summary?: string;
-  icp_summary?: string;
-  pricing_summary?: string;
-  differentiators?: unknown;
-  recent_signals?: unknown;
-};
-
 function asStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === "string" && item.length > 0);
 }
 
-export function SelfBriefView({ brief }: { brief: SelfBrief }) {
+function asOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// Accepts Record<string, unknown> because the brief comes from a Prisma
+// JsonValue column with no compile-time shape guarantees. Narrowing and
+// coercion happen per field inside this component.
+export function SelfBriefView({ brief }: { brief: Record<string, unknown> }) {
+  const positioning = asOptionalString(brief.positioning_summary);
+  const icp = asOptionalString(brief.icp_summary);
+  const pricing = asOptionalString(brief.pricing_summary);
   const differentiators = asStringArray(brief.differentiators);
   const recentSignals = asStringArray(brief.recent_signals);
 
   return (
     <div className="self-brief">
-      {brief.positioning_summary && (
+      {positioning && (
         <section className="brief-section">
           <h3 className="brief-section-label">Positioning</h3>
-          <p>{brief.positioning_summary}</p>
+          <p>{positioning}</p>
         </section>
       )}
-      {brief.icp_summary && (
+      {icp && (
         <section className="brief-section">
           <h3 className="brief-section-label">ICP</h3>
-          <p>{brief.icp_summary}</p>
+          <p>{icp}</p>
         </section>
       )}
-      {brief.pricing_summary && (
+      {pricing && (
         <section className="brief-section">
           <h3 className="brief-section-label">Pricing</h3>
-          <p>{brief.pricing_summary}</p>
+          <p>{pricing}</p>
         </section>
       )}
       {differentiators.length > 0 && (

--- a/components/dashboard/SelfProfileCard.tsx
+++ b/components/dashboard/SelfProfileCard.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import type { Competitor } from "@prisma/client";
+
+import { SelfBriefView } from "@/components/brief/SelfBriefView";
+
+function hasBriefShape(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function SelfProfileCard({ self }: { self: Competitor }) {
+  const brief = hasBriefShape(self.intelligenceBrief) ? self.intelligenceBrief : null;
+
+  return (
+    <section className="self-profile-card panel">
+      <header className="panel-header self-profile-card__header">
+        <div>
+          <span className="self-profile-card__eyebrow">Your Profile</span>
+          <h2>{self.name}</h2>
+        </div>
+        <Link href={`/${self.slug}`} className="tag-chip tag-chip--secondary">
+          View details →
+        </Link>
+      </header>
+      {brief ? (
+        <SelfBriefView brief={brief as never} />
+      ) : (
+        <p className="muted self-profile-card__empty">
+          Not yet analyzed — self-profile will populate on the next scan cycle.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/components/dashboard/SelfProfileCard.tsx
+++ b/components/dashboard/SelfProfileCard.tsx
@@ -22,7 +22,7 @@ export function SelfProfileCard({ self }: { self: Competitor }) {
         </Link>
       </header>
       {brief ? (
-        <SelfBriefView brief={brief as never} />
+        <SelfBriefView brief={brief} />
       ) : (
         <p className="muted self-profile-card__empty">
           Not yet analyzed — self-profile will populate on the next scan cycle.

--- a/docs/superpowers/plans/2026-04-21-self-profile.md
+++ b/docs/superpowers/plans/2026-04-21-self-profile.md
@@ -1,0 +1,2052 @@
+# Self-Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every AI call in Rival context about the user's own company so briefs, threat scores, and deep dives produce recommendations relative to the user instead of generic competitor commentary.
+
+**Architecture:** Reuse the `Competitor` model with a new `isSelf` boolean flag. Self goes through the existing scanner/cron/brief pipeline with a purpose-built self-brief schema. A new `buildSelfContext()` helper reads the self row's brief + manual_data and prepends it as a context block to every competitor-facing AI call (brief, research, future compare).
+
+**Tech Stack:** Next.js App Router, TypeScript strict, Prisma + Postgres, `@tabstack/sdk`, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-self-profile-design.md`
+
+---
+
+## Pre-flight
+
+- [ ] Confirm on branch `feat/self-profile-spec` (or create a new feature branch off it)
+- [ ] `npm install` clean
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+
+---
+
+## Task 1: Add `isSelf` column to Competitor
+
+**Files:**
+- Modify: `prisma/schema.prisma` (Competitor model, ~line 11)
+- Create: `prisma/migrations/<timestamp>_add_is_self_to_competitors/migration.sql`
+
+- [ ] **Step 1: Add `isSelf` field to the Prisma schema**
+
+Edit `prisma/schema.prisma`, inside the `Competitor` model. Insert after the `createdAt` line:
+
+```prisma
+  isSelf            Boolean   @default(false) @map("is_self")
+```
+
+- [ ] **Step 2: Create the migration**
+
+```bash
+npx prisma migrate dev --name add_is_self_to_competitors --create-only
+```
+
+- [ ] **Step 3: Edit the generated migration SQL**
+
+Open the newly created `prisma/migrations/<timestamp>_add_is_self_to_competitors/migration.sql` and append the partial unique index after the generated `ALTER TABLE` statement:
+
+```sql
+-- Enforce at most one Competitor row with is_self = true
+CREATE UNIQUE INDEX "competitors_is_self_unique"
+  ON "competitors" ("is_self") WHERE "is_self" = true;
+```
+
+- [ ] **Step 4: Apply the migration**
+
+```bash
+npx prisma migrate dev
+```
+
+Expected: migration applies cleanly, Prisma client regenerates.
+
+- [ ] **Step 5: Verify the constraint**
+
+```bash
+npx prisma studio
+```
+
+(Or via psql.) Manually: insert two rows with `is_self = true`, confirm the second fails with a unique-violation error. Then delete both test rows.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(schema): add is_self flag to competitors with partial unique index"
+```
+
+---
+
+## Task 2: Extend seed script to read `config.self`
+
+**Files:**
+- Modify: `scripts/seed.ts` (full file replacement of RivalConfig type + main loop)
+- Test: `scripts/__tests__/seed.test.ts` (create if absent; skip if integration-only seed tests aren't a pattern in this repo)
+
+- [ ] **Step 1: Write a failing unit test for config parsing**
+
+Create `lib/config/__tests__/rival-config.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { parseRivalConfig } from "@/lib/config/rival-config";
+
+describe("parseRivalConfig", () => {
+  it("parses config without a self block", () => {
+    const result = parseRivalConfig({
+      competitors: [{ name: "Acme", slug: "acme", url: "https://a.co", pages: [] }]
+    });
+    expect(result.self).toBeNull();
+    expect(result.competitors).toHaveLength(1);
+  });
+
+  it("parses a self block identically to a competitor entry", () => {
+    const result = parseRivalConfig({
+      self: {
+        name: "Rival",
+        slug: "rival",
+        url: "https://rival.so",
+        pages: [{ label: "Home", url: "https://rival.so", type: "homepage" }]
+      },
+      competitors: []
+    });
+    expect(result.self).not.toBeNull();
+    expect(result.self?.slug).toBe("rival");
+    expect(result.self?.pages).toHaveLength(1);
+  });
+
+  it("rejects a self entry whose slug collides with a competitor slug", () => {
+    expect(() =>
+      parseRivalConfig({
+        self: { name: "Rival", slug: "acme", url: "https://rival.so", pages: [] },
+        competitors: [{ name: "Acme", slug: "acme", url: "https://a.co", pages: [] }]
+      })
+    ).toThrow(/slug.*collision|duplicate slug/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npm run test -- rival-config
+```
+
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the parser module**
+
+Create `lib/config/rival-config.ts`:
+
+```ts
+export type RivalConfigEntry = {
+  name: string;
+  slug: string;
+  url: string;
+  manual?: Record<string, unknown> & { manual_last_updated?: string };
+  pages?: Array<{
+    label: string;
+    url: string;
+    type: string;
+    geo_target?: string;
+  }>;
+};
+
+export type ParsedRivalConfig = {
+  self: RivalConfigEntry | null;
+  competitors: RivalConfigEntry[];
+};
+
+type RawConfig = {
+  self?: RivalConfigEntry;
+  competitors?: RivalConfigEntry[];
+};
+
+export function parseRivalConfig(raw: RawConfig): ParsedRivalConfig {
+  const self = raw.self ?? null;
+  const competitors = raw.competitors ?? [];
+
+  if (self) {
+    const collision = competitors.find((c) => c.slug === self.slug);
+    if (collision) {
+      throw new Error(
+        `rivals.config.json: slug collision between self and competitor "${self.slug}". Choose a different slug for one of them.`
+      );
+    }
+  }
+
+  return { self, competitors };
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- rival-config
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Rewire `scripts/seed.ts` to use the parser and upsert self**
+
+Replace the top of `scripts/seed.ts`:
+
+```ts
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/client";
+import { parseRivalConfig, type RivalConfigEntry } from "@/lib/config/rival-config";
+
+async function loadConfig() {
+  const configPath = path.join(process.cwd(), "rivals.config.json");
+  const raw = await fs.readFile(configPath, "utf8");
+  return parseRivalConfig(JSON.parse(raw));
+}
+
+function toDate(value?: string): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toJsonValue(value: unknown): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
+  if (value === null || value === undefined) return Prisma.JsonNull;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
+    return value as Prisma.InputJsonValue;
+  }
+  return String(value);
+}
+
+async function upsertEntry(entry: RivalConfigEntry, isSelf: boolean) {
+  const record = await prisma.competitor.upsert({
+    where: { slug: entry.slug },
+    create: {
+      name: entry.name,
+      slug: entry.slug,
+      baseUrl: entry.url,
+      isSelf,
+      manualData: toJsonValue(entry.manual),
+      manualLastUpdated: toDate(entry.manual?.manual_last_updated)
+    },
+    update: {
+      name: entry.name,
+      baseUrl: entry.url,
+      isSelf,
+      manualData: toJsonValue(entry.manual),
+      manualLastUpdated: toDate(entry.manual?.manual_last_updated)
+    }
+  });
+
+  const configUrls = new Set((entry.pages ?? []).map((p) => p.url));
+
+  for (const page of entry.pages ?? []) {
+    const existing = await prisma.competitorPage.findFirst({
+      where: { competitorId: record.id, url: page.url }
+    });
+
+    if (existing) {
+      await prisma.competitorPage.update({
+        where: { id: existing.id },
+        data: { label: page.label, type: page.type, geoTarget: page.geo_target ?? null }
+      });
+    } else {
+      await prisma.competitorPage.create({
+        data: {
+          competitorId: record.id,
+          label: page.label,
+          url: page.url,
+          type: page.type,
+          geoTarget: page.geo_target ?? null
+        }
+      });
+    }
+  }
+
+  return { record, configUrls };
+}
+```
+
+Replace the `main()` function body (keep the existing `--prune-pages` behavior, now applied to both self and competitors):
+
+```ts
+async function main() {
+  const prunePages = process.argv.includes("--prune-pages");
+  const config = await loadConfig();
+  const entries: Array<{ entry: RivalConfigEntry; isSelf: boolean }> = [];
+  if (config.self) entries.push({ entry: config.self, isSelf: true });
+  for (const c of config.competitors) entries.push({ entry: c, isSelf: false });
+
+  if (entries.length === 0) {
+    console.log("No self or competitors in rivals.config.json, nothing to seed.");
+    return;
+  }
+
+  for (const { entry, isSelf } of entries) {
+    const { record, configUrls } = await upsertEntry(entry, isSelf);
+
+    const dbPages = await prisma.competitorPage.findMany({ where: { competitorId: record.id } });
+    const orphaned = dbPages.filter((p) => !configUrls.has(p.url));
+
+    if (orphaned.length > 0) {
+      if (prunePages) {
+        await prisma.competitorPage.deleteMany({
+          where: { id: { in: orphaned.map((p) => p.id) } }
+        });
+        console.warn(
+          `  Pruned ${orphaned.length} page(s) for ${record.slug} (scan history deleted): ${orphaned.map((p) => p.url).join(", ")}`
+        );
+      } else {
+        console.warn(
+          `  Warning: ${orphaned.length} page(s) in DB but not in config for ${record.slug} — cron will keep scanning them. Run with --prune-pages to remove (deletes scan history): ${orphaned.map((p) => p.url).join(", ")}`
+        );
+      }
+    }
+
+    console.log(`Seeded ${isSelf ? "[self] " : ""}${record.name} (${record.slug})`);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+```
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/config scripts/seed.ts
+git commit -m "feat(seed): upsert self entry from rivals.config.json"
+```
+
+---
+
+## Task 3: Self-profile schema + `generateSelfProfile` in `lib/tabstack/generate.ts`
+
+**Files:**
+- Modify: `lib/tabstack/generate.ts` (append new schema + function)
+- Test: `lib/tabstack/__tests__/generate.test.ts` (add new test block)
+
+- [ ] **Step 1: Write a failing test**
+
+Append to `lib/tabstack/__tests__/generate.test.ts`:
+
+```ts
+describe("generateSelfProfile", () => {
+  it("calls tabstack /generate with SELF_PROFILE_SCHEMA and the provided context", async () => {
+    const { generateSelfProfile, SELF_PROFILE_EXPECTED_FIELDS } = await import("@/lib/tabstack/generate");
+    // (Reuse existing client+logger mocks from the top of this file.)
+
+    const response = await generateSelfProfile({
+      competitorId: "self_1",
+      url: "https://rival.so",
+      contextData: JSON.stringify([{ page_type: "homepage", result: { headline: "CI for devs" } }]),
+      effort: "low",
+      nocache: true
+    });
+
+    expect(response).toBeDefined();
+    expect(SELF_PROFILE_EXPECTED_FIELDS).toEqual(
+      expect.arrayContaining([
+        "positioning_summary",
+        "icp_summary",
+        "pricing_summary",
+        "differentiators",
+        "recent_signals"
+      ])
+    );
+    // The mocked client should have been called once with the self-profile schema.
+    // (Match the existing test pattern in this file: assert on the mocked client's call args.)
+  });
+});
+```
+
+(The existing test file will show the mock-wiring pattern for `getTabstackClient`. Follow it exactly when filling in the assertion on call args.)
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- generate
+```
+
+Expected: FAIL (`generateSelfProfile` / `SELF_PROFILE_EXPECTED_FIELDS` not exported).
+
+- [ ] **Step 3: Add the schema and function to `lib/tabstack/generate.ts`**
+
+After the existing `BRIEF_SCHEMA` constant, add:
+
+```ts
+export const SELF_PROFILE_SCHEMA = {
+  type: "object",
+  properties: {
+    positioning_summary: {
+      type: "string",
+      description: "1–2 sentences describing who this company is and what it sells."
+    },
+    icp_summary: {
+      type: "string",
+      description: "1–2 sentences describing the company's ideal customer profile."
+    },
+    pricing_summary: {
+      type: "string",
+      description: "Brief description of the monetization model (free, paid, freemium, OSS+paid, etc.)."
+    },
+    differentiators: {
+      type: "array",
+      items: { type: "string" },
+      description: "3–5 bullets naming what makes this company distinct."
+    },
+    recent_signals: {
+      type: "array",
+      items: { type: "string" },
+      description: "3–5 bullets of recent changes visible from changelog, blog, or careers."
+    }
+  },
+  required: ["positioning_summary", "icp_summary", "pricing_summary", "differentiators", "recent_signals"]
+} as const;
+
+export const SELF_PROFILE_EXPECTED_FIELDS: string[] = [...SELF_PROFILE_SCHEMA.required];
+```
+
+After `generateBrief`, add:
+
+```ts
+export type GenerateSelfProfileInput = GenerateBriefInput;
+
+/**
+ * Analyze the user's own company data and produce a structured self-profile.
+ * This output is stored on the self Competitor row and later injected as context
+ * into every competitor-facing AI call (brief, research, compare).
+ */
+export async function generateSelfProfile(input: GenerateSelfProfileInput): Promise<GenerateJsonResponse> {
+  const client = getTabstackClient();
+  const geoTarget = toGeoTarget(input.geoTarget);
+  const contextData = input.contextData.slice(0, MAX_CONTEXT_LENGTH);
+  if (input.contextData.length > MAX_CONTEXT_LENGTH) {
+    process.emitWarning(
+      `[generateSelfProfile] contextData truncated from ${input.contextData.length} to ${MAX_CONTEXT_LENGTH} chars`,
+      { code: "RIVAL_CONTEXT_TRUNCATED" }
+    );
+  }
+
+  const instructions = `You are analyzing a company's own public surfaces (website, pricing,
+docs, changelog, careers, blog, social) to produce a concise self-profile. This
+profile will later be used as context when evaluating competitors, so it must be
+factual and compact.
+
+Produce:
+1. positioning_summary — 1–2 sentences: who they are, what they sell.
+2. icp_summary — 1–2 sentences: who they serve (technical ICP + use case).
+3. pricing_summary — monetization model in one short paragraph.
+4. differentiators — 3–5 bullets of what makes them distinct (not marketing fluff).
+5. recent_signals — 3–5 bullets of recent changes visible in changelog, blog, or careers.
+
+Be direct and specific. No generic commentary. Do not speculate — only describe
+what the data shows.
+
+Company data:
+${contextData}`;
+
+  const requestPayload: GenerateJsonParams = {
+    url: input.url,
+    instructions,
+    json_schema: SELF_PROFILE_SCHEMA,
+    effort: toSdkEffort(input.effort),
+    nocache: input.nocache,
+    geo_target: geoTarget
+  };
+
+  return logger.call(() => client.generate.json(requestPayload), {
+    competitorId: input.competitorId,
+    pageId: input.pageId,
+    endpoint: "generate",
+    url: input.url,
+    effort: input.effort,
+    nocache: input.nocache,
+    geoTarget: geoTarget?.country,
+    isDemo: input.isDemo,
+    fallback: input.fallback,
+    expectedFields: SELF_PROFILE_EXPECTED_FIELDS
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- generate
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/tabstack/generate.ts lib/tabstack/__tests__/generate.test.ts
+git commit -m "feat(tabstack): add generateSelfProfile + SELF_PROFILE_SCHEMA"
+```
+
+---
+
+## Task 4: `generateSelfBrief` orchestrator in `lib/brief.ts`
+
+**Files:**
+- Modify: `lib/brief.ts`
+- Test: `lib/__tests__/brief.test.ts` (add new describe block)
+
+- [ ] **Step 1: Write a failing test**
+
+Append a new `describe` block to `lib/__tests__/brief.test.ts` (mirror the existing `generateCompetitorBrief` test setup — same mocks plus a new `generateSelfProfileMock`):
+
+```ts
+describe("generateSelfBrief", () => {
+  beforeEach(() => {
+    competitorFindUniqueMock.mockReset();
+    scanFindManyMock.mockReset();
+    competitorUpdateMock.mockReset();
+    // If you add `generateSelfProfileMock` to the hoisted vi.mock block, reset it here too.
+  });
+
+  it("stores the self-profile output on the self Competitor row", async () => {
+    competitorFindUniqueMock.mockResolvedValue({
+      ...COMPETITOR,
+      isSelf: true
+    });
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+    // generateSelfProfileMock returns a valid payload
+    // competitorUpdateMock asserts intelligenceBrief = self profile shape, threatLevel = null
+
+    const { generateSelfBrief } = await import("@/lib/brief");
+    const payload = await generateSelfBrief("cmp_1", true);
+
+    expect(payload).toMatchObject({
+      positioning_summary: expect.any(String),
+      icp_summary: expect.any(String),
+      pricing_summary: expect.any(String)
+    });
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "cmp_1" },
+        data: expect.objectContaining({ threatLevel: null })
+      })
+    );
+  });
+
+  it("throws when no recent scans exist", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([]);
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await expect(generateSelfBrief("cmp_1")).rejects.toThrow(/no recent scans/i);
+  });
+});
+```
+
+Update the top-of-file hoisted `vi.mock` block to also export `generateSelfProfileMock` and reshape the `@/lib/tabstack/generate` mock:
+
+```ts
+const {
+  competitorFindUniqueMock,
+  scanFindManyMock,
+  competitorUpdateMock,
+  generateBriefMock,
+  generateSelfProfileMock
+} = vi.hoisted(() => ({
+  competitorFindUniqueMock: vi.fn(),
+  scanFindManyMock: vi.fn(),
+  competitorUpdateMock: vi.fn(),
+  generateBriefMock: vi.fn(),
+  generateSelfProfileMock: vi.fn().mockResolvedValue({
+    positioning_summary: "Rival is a competitive intelligence tool.",
+    icp_summary: "Developers tracking competitors.",
+    pricing_summary: "Open source, self-hosted.",
+    differentiators: ["Powered by Tabstack", "Open source"],
+    recent_signals: ["Added self-profile feature"]
+  })
+}));
+
+vi.mock("@/lib/tabstack/generate", () => ({
+  generateBrief: generateBriefMock,
+  generateSelfProfile: generateSelfProfileMock
+}));
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- brief
+```
+
+Expected: FAIL (`generateSelfBrief` not exported).
+
+- [ ] **Step 3: Add `generateSelfBrief` to `lib/brief.ts`**
+
+At the top, update imports:
+
+```ts
+import { generateBrief, generateSelfProfile } from "@/lib/tabstack/generate";
+```
+
+Add a constant above the functions (self's brief considers a broader page set than competitor brief — we include everything we've got):
+
+```ts
+const SELF_BRIEF_PAGE_TYPES: Set<string> | null = null; // null = include all page types
+```
+
+Below `generateCompetitorBrief`, add:
+
+```ts
+export async function generateSelfBrief(competitorId: string, nocache = true) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { id: competitorId },
+    include: { pages: true }
+  });
+
+  if (!competitor) {
+    throw new Error("Competitor not found");
+  }
+
+  const staleThreshold = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7); // 7 days
+  const scans = await prisma.scan.findMany({
+    where: { page: { competitorId } },
+    include: { page: true },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  const latestByPage = new Map<string, { pageType: string; pageLabel: string; result: unknown }>();
+  for (const scan of scans) {
+    if (latestByPage.has(scan.pageId)) continue;
+    if (scan.scannedAt < staleThreshold) continue;
+    latestByPage.set(scan.pageId, {
+      pageType: scan.page.type,
+      pageLabel: scan.page.label,
+      result: scan.markdownResult ?? scan.rawResult
+    });
+  }
+
+  if (latestByPage.size === 0) {
+    throw new Error("No recent scans available for self-profile generation");
+  }
+
+  // Self brief includes ALL page types. Unlike competitor briefs, we want every
+  // signal from the user's own surfaces so the injected context is maximally
+  // useful downstream.
+  const contextData = JSON.stringify(
+    [...latestByPage.values()].map((scan) => ({
+      page_type: scan.pageType,
+      page_label: scan.pageLabel,
+      result: truncateResult(scan.result)
+    }))
+  );
+
+  const response = await generateSelfProfile({
+    competitorId,
+    url: competitor.baseUrl,
+    contextData,
+    effort: "low",
+    nocache
+  });
+
+  const payload = extractBriefPayload(response);
+
+  await prisma.competitor.update({
+    where: { id: competitorId },
+    data: {
+      intelligenceBrief: toJsonValue(payload),
+      threatLevel: null,
+      briefGeneratedAt: new Date()
+    }
+  });
+
+  return payload;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- brief
+```
+
+Expected: PASS (both existing `generateCompetitorBrief` tests AND new `generateSelfBrief` tests).
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/brief.ts lib/__tests__/brief.test.ts
+git commit -m "feat(brief): add generateSelfBrief for self Competitor rows"
+```
+
+---
+
+## Task 5: Branch `run-scans.ts` and `bootstrap-new-competitors.ts` on `isSelf`
+
+**Files:**
+- Modify: `lib/run-scans.ts`
+- Modify: `scripts/bootstrap-new-competitors.ts`
+- Test: `lib/__tests__/run-scans.test.ts` (check if this exists; if not, create minimal test)
+
+- [ ] **Step 1: Write a failing test for `run-scans.ts` branching**
+
+If `lib/__tests__/run-scans.test.ts` doesn't exist, create it. Mirror the Prisma mocking pattern from `brief.test.ts`. Key test:
+
+```ts
+it("calls generateSelfBrief for isSelf competitors and generateCompetitorBrief for others", async () => {
+  competitorFindManyMock.mockResolvedValue([
+    { id: "cmp_a", isSelf: false, pages: [] },
+    { id: "cmp_self", isSelf: true, pages: [] }
+  ]);
+  scanPageMock.mockResolvedValue({});
+  const { runScans } = await import("@/lib/run-scans");
+  await runScans();
+
+  expect(generateCompetitorBriefMock).toHaveBeenCalledWith("cmp_a", expect.any(Boolean));
+  expect(generateSelfBriefMock).toHaveBeenCalledWith("cmp_self", expect.any(Boolean));
+});
+```
+
+Wire the hoisted mocks to export `generateCompetitorBriefMock`, `generateSelfBriefMock`, `scanPageMock`, `competitorFindManyMock` as appropriate.
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- run-scans
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `lib/run-scans.ts`**
+
+Import `generateSelfBrief`:
+
+```ts
+import { generateCompetitorBrief, generateSelfBrief } from "./brief";
+```
+
+Update the `CompetitorWithPages` type:
+
+```ts
+type CompetitorWithPages = {
+  id: string;
+  isSelf: boolean;
+  pages: Array<{
+    id: string;
+    label: string;
+    url: string;
+    type: string;
+    geoTarget: string | null;
+  }>;
+};
+```
+
+Update `processCompetitor` to branch on `competitor.isSelf`:
+
+```ts
+try {
+  if (competitor.isSelf) {
+    await generateSelfBrief(competitor.id, briefNocache);
+  } else {
+    await generateCompetitorBrief(competitor.id, briefNocache);
+  }
+  item.briefGenerated = true;
+} catch (error) {
+  item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);
+}
+```
+
+No change needed to the `prisma.competitor.findMany` call — it returns `isSelf` automatically with the full model.
+
+- [ ] **Step 4: Update `scripts/bootstrap-new-competitors.ts`**
+
+Import `generateSelfBrief`:
+
+```ts
+import { generateCompetitorBrief, generateSelfBrief } from "@/lib/brief";
+```
+
+Update the `bootstrapCompetitor` parameter type:
+
+```ts
+async function bootstrapCompetitor(competitor: {
+  id: string;
+  slug: string;
+  name: string;
+  isSelf: boolean;
+  pages: Array<{ id: string; label: string; url: string; type: string; geoTarget: string | null }>;
+}) {
+```
+
+And its brief-gen block:
+
+```ts
+console.log(`[bootstrap] ${competitor.slug}: generating brief...`);
+try {
+  const payload = competitor.isSelf
+    ? await generateSelfBrief(competitor.id, true)
+    : await generateCompetitorBrief(competitor.id, true);
+  const threat = competitor.isSelf ? "—" : ((payload as { threat_level?: string })?.threat_level ?? "—");
+  console.log(
+    `[bootstrap] ${competitor.slug}: brief generated (${competitor.isSelf ? "self-profile" : `threat=${threat}`}, scan errors=${scanErrors}).`
+  );
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[bootstrap] ${competitor.slug}: brief failed: ${message}`);
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+npm run test
+```
+
+Expected: PASS — all brief and run-scans tests green.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/run-scans.ts scripts/bootstrap-new-competitors.ts lib/__tests__/run-scans.test.ts
+git commit -m "feat(scans): branch cron + bootstrap brief gen on isSelf"
+```
+
+---
+
+## Task 6: `buildSelfContext` helper
+
+**Files:**
+- Create: `lib/context/self-context.ts`
+- Create: `lib/context/__tests__/self-context.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `lib/context/__tests__/self-context.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { competitorFindFirstMock } = vi.hoisted(() => ({
+  competitorFindFirstMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: {
+      findFirst: competitorFindFirstMock
+    }
+  }
+}));
+
+describe("buildSelfContext", () => {
+  beforeEach(() => {
+    competitorFindFirstMock.mockReset();
+  });
+
+  it("returns null when no self row exists", async () => {
+    competitorFindFirstMock.mockResolvedValue(null);
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when self row has no intelligenceBrief", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: null,
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toBeNull();
+  });
+
+  it("returns a compact context string when brief is present", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "CI tool for devs",
+        icp_summary: "Developers tracking competitors",
+        pricing_summary: "Open source, self-hosted",
+        differentiators: ["Powered by Tabstack", "Open source"],
+        recent_signals: ["Added self-profile"]
+      },
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).not.toBeNull();
+    expect(result).toContain("Rival");
+    expect(result).toContain("CI tool for devs");
+    expect(result).toContain("Powered by Tabstack");
+    expect(result!.length).toBeLessThanOrEqual(1200); // 800 target + framing overhead
+  });
+
+  it("lets manual_data override brief fields", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "OLD positioning",
+        icp_summary: "Devs",
+        pricing_summary: "Free",
+        differentiators: [],
+        recent_signals: []
+      },
+      manualData: { positioning_summary: "NEW positioning" }
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toContain("NEW positioning");
+    expect(result).not.toContain("OLD positioning");
+  });
+
+  it("skips injection when isDemo is true", async () => {
+    // Even if a self row exists, demo scans must not inject self-context.
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: { positioning_summary: "x", icp_summary: "x", pricing_summary: "x", differentiators: [], recent_signals: [] },
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext({ isDemo: true });
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- self-context
+```
+
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create `lib/context/self-context.ts`**
+
+```ts
+/**
+ * Builds a compact context string describing the user's own company,
+ * for injection into every competitor-facing AI call (brief, research, compare).
+ *
+ * When:
+ * - Returns null if no self row exists, or if the self brief has not yet been
+ *   generated. Callers pass through without injection.
+ * - Returns null when isDemo is true. Demo scans target arbitrary URLs the user
+ *   pastes, which are not the operator's product — injecting self-context
+ *   would poison the output.
+ *
+ * Output shape: a short prose block capped at ~800 chars of payload, with
+ * framing that tells the downstream prompt NOT to echo it back.
+ */
+
+import { prisma } from "@/lib/db/client";
+import { isPlainObject } from "@/lib/utils/types";
+
+const MAX_PAYLOAD_CHARS = 800;
+
+type SelfBriefShape = {
+  positioning_summary?: string;
+  icp_summary?: string;
+  pricing_summary?: string;
+  differentiators?: string[];
+  recent_signals?: string[];
+};
+
+function mergeBriefAndManual(
+  brief: SelfBriefShape,
+  manual: Record<string, unknown> | null
+): { fields: SelfBriefShape; extras: Record<string, unknown> } {
+  if (!manual) return { fields: brief, extras: {} };
+  const merged: SelfBriefShape = { ...brief };
+  const extras: Record<string, unknown> = {};
+  const knownKeys = new Set([
+    "positioning_summary",
+    "icp_summary",
+    "pricing_summary",
+    "differentiators",
+    "recent_signals"
+  ]);
+  for (const [key, value] of Object.entries(manual)) {
+    if (knownKeys.has(key)) {
+      (merged as Record<string, unknown>)[key] = value;
+    } else {
+      extras[key] = value;
+    }
+  }
+  return { fields: merged, extras };
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return text.slice(0, limit) + "…";
+}
+
+export type BuildSelfContextOptions = {
+  isDemo?: boolean;
+};
+
+export async function buildSelfContext(options: BuildSelfContextOptions = {}): Promise<string | null> {
+  if (options.isDemo) return null;
+
+  const self = await prisma.competitor.findFirst({
+    where: { isSelf: true }
+  });
+
+  if (!self) return null;
+  if (!self.intelligenceBrief || !isPlainObject(self.intelligenceBrief)) return null;
+
+  const brief = self.intelligenceBrief as SelfBriefShape;
+  const manual = isPlainObject(self.manualData) ? (self.manualData as Record<string, unknown>) : null;
+  const { fields, extras } = mergeBriefAndManual(brief, manual);
+
+  const parts: string[] = [];
+  parts.push(`Name: ${self.name}`);
+  if (fields.positioning_summary) parts.push(`Positioning: ${fields.positioning_summary}`);
+  if (fields.icp_summary) parts.push(`ICP: ${fields.icp_summary}`);
+  if (fields.pricing_summary) parts.push(`Pricing: ${fields.pricing_summary}`);
+  if (fields.differentiators?.length) {
+    parts.push(`What makes us distinct: ${fields.differentiators.join("; ")}`);
+  }
+  if (fields.recent_signals?.length) {
+    parts.push(`Recent signals: ${fields.recent_signals.join("; ")}`);
+  }
+  if (Object.keys(extras).length > 0) {
+    parts.push(`User notes: ${JSON.stringify(extras)}`);
+  }
+
+  const payload = truncate(parts.join("\n"), MAX_PAYLOAD_CHARS);
+
+  return `CONTEXT — about the user's own company (who this brief is for):
+${payload}
+Use this to frame recommendations, threat levels, and opportunities relative to THIS company specifically. Do not echo this context in the output.`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- self-context
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/context
+git commit -m "feat(context): add buildSelfContext helper"
+```
+
+---
+
+## Task 7: Inject self-context into `generateBrief`
+
+**Files:**
+- Modify: `lib/tabstack/generate.ts` (`generateBrief` only — NOT `generateSelfProfile`)
+- Test: `lib/tabstack/__tests__/generate.test.ts`
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `lib/tabstack/__tests__/generate.test.ts`. At the top, extend the hoisted mock block to include `buildSelfContextMock`:
+
+```ts
+const { /* existing mocks */, buildSelfContextMock } = vi.hoisted(() => ({
+  /* existing mocks */,
+  buildSelfContextMock: vi.fn()
+}));
+
+vi.mock("@/lib/context/self-context", () => ({
+  buildSelfContext: buildSelfContextMock
+}));
+```
+
+Add a test:
+
+```ts
+describe("generateBrief with self-context injection", () => {
+  beforeEach(() => {
+    buildSelfContextMock.mockReset();
+  });
+
+  it("prepends self-context to instructions when buildSelfContext returns a string", async () => {
+    buildSelfContextMock.mockResolvedValue("CONTEXT — about the user's own company...\nName: Rival");
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: JSON.stringify([{ page_type: "homepage", result: {} }]),
+      effort: "low",
+      nocache: true
+    });
+
+    // Assert the mocked Tabstack client was called with instructions containing BOTH
+    // "CONTEXT — about the user's own company" AND "Additional competitor context:"
+    // (match the existing pattern in this test file for grabbing call args.)
+  });
+
+  it("calls generate without self-context prefix when buildSelfContext returns null", async () => {
+    buildSelfContextMock.mockResolvedValue(null);
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    // Assert instructions does NOT contain "CONTEXT — about the user's own company".
+  });
+
+  it("does not inject self-context for demo calls", async () => {
+    buildSelfContextMock.mockImplementation(async (opts: { isDemo?: boolean }) =>
+      opts?.isDemo ? null : "CONTEXT — about the user's own company..."
+    );
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: null,
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true,
+      isDemo: true
+    });
+
+    // Assert instructions does NOT contain the self-context block.
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- generate
+```
+
+Expected: FAIL (injection not implemented).
+
+- [ ] **Step 3: Update `generateBrief` in `lib/tabstack/generate.ts`**
+
+Import at the top:
+
+```ts
+import { buildSelfContext } from "@/lib/context/self-context";
+```
+
+Modify `generateBrief` to call `buildSelfContext` and prepend the result when non-null. Inside `generateBrief`, replace the `const instructions = ...` block:
+
+```ts
+const selfContext = await buildSelfContext({ isDemo: input.isDemo });
+const instructions = `${selfContext ? `${selfContext}\n\n` : ""}You are a competitive intelligence analyst. Based on this competitor data,
+produce a structured brief covering:
+[... existing instructions body unchanged ...]
+
+Additional competitor context:
+${contextData}`;
+```
+
+(Keep the full existing rubric inside the instructions — don't truncate.)
+
+**Do NOT modify `generateSelfProfile`.** It is analyzing self, not competitors — it must not inject self-context into its own prompt.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- generate
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/tabstack/generate.ts lib/tabstack/__tests__/generate.test.ts
+git commit -m "feat(brief): inject self-context into competitor brief prompts"
+```
+
+---
+
+## Task 8: Inject self-context into `runResearch`
+
+**Files:**
+- Modify: `lib/tabstack/research.ts`
+- Test: `lib/tabstack/__tests__/research.test.ts` (check if exists; if not, create with same mocking pattern)
+
+- [ ] **Step 1: Write a failing test**
+
+In the research test file (create if needed), mock `buildSelfContext` and assert:
+
+```ts
+it("prepends self-context to the research query when buildSelfContext returns a string", async () => {
+  buildSelfContextMock.mockResolvedValue("CONTEXT — about the user's own company...\nName: Rival");
+
+  const { runResearch } = await import("@/lib/tabstack/research");
+  await runResearch({
+    competitorId: "cmp_1",
+    query: "What are customers saying about Acme?",
+    mode: "fast"
+  });
+
+  // Assert mocked client.agent.research was called with a query containing BOTH
+  // "CONTEXT — about the user's own company" AND the original question.
+});
+
+it("leaves the research query untouched when buildSelfContext returns null", async () => {
+  buildSelfContextMock.mockResolvedValue(null);
+  const { runResearch } = await import("@/lib/tabstack/research");
+  await runResearch({
+    competitorId: "cmp_1",
+    query: "What are customers saying about Acme?",
+    mode: "fast"
+  });
+  // Assert the mocked research call received the query unchanged.
+});
+
+it("does not inject self-context for demo research calls", async () => {
+  buildSelfContextMock.mockImplementation(async (opts: { isDemo?: boolean }) =>
+    opts?.isDemo ? null : "CONTEXT..."
+  );
+  const { runResearch } = await import("@/lib/tabstack/research");
+  await runResearch({
+    competitorId: null,
+    query: "Anything",
+    mode: "fast",
+    isDemo: true
+  });
+  // Assert no self-context in query.
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- research
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `runResearch` in `lib/tabstack/research.ts`**
+
+Import:
+
+```ts
+import { buildSelfContext } from "@/lib/context/self-context";
+```
+
+Modify the start of `runResearch`'s `logger.call` body:
+
+```ts
+return logger.call(
+  async () => {
+    const selfContext = await buildSelfContext({ isDemo: input.isDemo });
+    const query = selfContext
+      ? `${selfContext}\n\nRESEARCH QUESTION:\n${input.query}`
+      : input.query;
+
+    const stream = await client.agent.research({
+      query,
+      mode: input.mode,
+      nocache: input.nocache
+    });
+
+    const { events, result, citations, error } = await collectStream(
+      stream,
+      input.maxStreamEvents ?? DEFAULT_MAX_STREAM_EVENTS
+    );
+    return { events, result, citations, error } satisfies ResearchResult;
+  },
+  // ... logger metadata unchanged
+);
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- research
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/tabstack/research.ts lib/tabstack/__tests__/research.test.ts
+git commit -m "feat(research): inject self-context into deep-dive research queries"
+```
+
+---
+
+## Task 9: Filter self from competitor listings
+
+**Files:**
+- Modify: `lib/db/competitors.ts`
+- Modify: `app/api/competitors/route.ts` (if any change needed)
+- Modify: `app/page.tsx` (dashboard — it calls `prisma.competitor.findMany` directly)
+- Test: `lib/db/__tests__/competitors.test.ts` (create or extend)
+
+- [ ] **Step 1: Write a failing test for `listCompetitors`**
+
+Create or extend `lib/db/__tests__/competitors.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findManyMock } = vi.hoisted(() => ({
+  findManyMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: { competitor: { findMany: findManyMock } }
+}));
+
+describe("listCompetitors", () => {
+  beforeEach(() => findManyMock.mockReset());
+
+  it("excludes self rows by default", async () => {
+    findManyMock.mockResolvedValue([]);
+    const { listCompetitors } = await import("@/lib/db/competitors");
+    await listCompetitors();
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { isSelf: false } })
+    );
+  });
+
+  it("includes self when includeSelf is true", async () => {
+    findManyMock.mockResolvedValue([]);
+    const { listCompetitors } = await import("@/lib/db/competitors");
+    await listCompetitors({ includeSelf: true });
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ where: { isSelf: false } })
+    );
+  });
+});
+
+describe("getSelfCompetitor", () => {
+  beforeEach(() => findManyMock.mockReset());
+  // Extend with mocks for findFirst if needed
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- competitors
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `lib/db/competitors.ts`**
+
+```ts
+import { prisma } from "@/lib/db/client";
+
+export type CompetitorListFilters = {
+  includePages?: boolean;
+  includeSelf?: boolean;
+};
+
+export async function listCompetitors(filters: CompetitorListFilters = {}) {
+  return prisma.competitor.findMany({
+    where: filters.includeSelf ? undefined : { isSelf: false },
+    orderBy: { name: "asc" },
+    include: filters.includePages ? { pages: true } : undefined
+  });
+}
+
+export async function getCompetitorById(id: string) {
+  return prisma.competitor.findUnique({
+    where: { id },
+    include: { pages: true }
+  });
+}
+
+export async function getCompetitorBySlug(slug: string) {
+  return prisma.competitor.findUnique({
+    where: { slug },
+    include: { pages: true }
+  });
+}
+
+export async function getSelfCompetitor() {
+  return prisma.competitor.findFirst({
+    where: { isSelf: true },
+    include: { pages: true }
+  });
+}
+```
+
+- [ ] **Step 4: Update `app/page.tsx` dashboard query**
+
+In `app/page.tsx`, inside `loadDashboardData`, change the competitor query:
+
+```ts
+const competitors = await prisma.competitor.findMany({
+  where: { isSelf: false },
+  orderBy: { name: "asc" }
+});
+```
+
+(This keeps existing filtering, analysis, intel feed code unchanged — they already operate on `competitorIds` which now excludes self.)
+
+- [ ] **Step 5: Verify `app/api/competitors/route.ts`**
+
+No change required — it calls `listCompetitors({ includePages: true })` which now filters self automatically.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npm run test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/db/competitors.ts lib/db/__tests__/competitors.test.ts app/page.tsx
+git commit -m "feat(db,ui): exclude self from competitor listings by default"
+```
+
+---
+
+## Task 10: `/api/self` route
+
+**Files:**
+- Create: `app/api/self/route.ts`
+- Create: `app/api/self/__tests__/route.test.ts`
+
+- [ ] **Step 1: Write a failing test**
+
+Create `app/api/self/__tests__/route.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+const { getSelfCompetitorMock, hasValidInternalApiKeyMock, isSameOriginRequestMock } = vi.hoisted(() => ({
+  getSelfCompetitorMock: vi.fn(),
+  hasValidInternalApiKeyMock: vi.fn(),
+  isSameOriginRequestMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/competitors", () => ({
+  getSelfCompetitor: getSelfCompetitorMock
+}));
+
+vi.mock("@/app/api/_lib/auth", () => ({
+  hasValidInternalApiKey: hasValidInternalApiKeyMock,
+  isSameOriginRequest: isSameOriginRequestMock
+}));
+
+describe("/api/self", () => {
+  it("returns 403 when neither internal key nor same origin", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(false);
+    isSameOriginRequestMock.mockReturnValue(false);
+    const { GET } = await import("@/app/api/self/route");
+    const response = await GET(new Request("http://localhost/api/self") as any);
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 200 with self payload when present", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(true);
+    isSameOriginRequestMock.mockReturnValue(true);
+    getSelfCompetitorMock.mockResolvedValue({ id: "self_1", name: "Rival", isSelf: true, pages: [] });
+    const { GET } = await import("@/app/api/self/route");
+    const response = await GET(new Request("http://localhost/api/self") as any);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.self?.slug).toBeUndefined(); // slug not required but name is
+    expect(body.self?.name).toBe("Rival");
+  });
+
+  it("returns 200 with self: null when no self row exists", async () => {
+    hasValidInternalApiKeyMock.mockReturnValue(true);
+    isSameOriginRequestMock.mockReturnValue(true);
+    getSelfCompetitorMock.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/self/route");
+    const response = await GET(new Request("http://localhost/api/self") as any);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.self).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- api/self
+```
+
+Expected: FAIL (route not found).
+
+- [ ] **Step 3: Create the route**
+
+Create `app/api/self/route.ts`:
+
+```ts
+import { NextResponse, type NextRequest } from "next/server";
+
+import { hasValidInternalApiKey, isSameOriginRequest } from "@/app/api/_lib/auth";
+import { getSelfCompetitor } from "@/lib/db/competitors";
+
+export async function GET(request: NextRequest) {
+  if (!hasValidInternalApiKey(request) && !isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const self = await getSelfCompetitor();
+    return NextResponse.json({ self });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load self profile";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm run test -- api/self
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/self
+git commit -m "feat(api): add /api/self read endpoint"
+```
+
+---
+
+## Task 11: "Your Profile" dashboard section + detail page branching
+
+**Files:**
+- Modify: `app/page.tsx` (add Your Profile section)
+- Modify: `app/[slug]/page.tsx` (hide threat UI for self; branch brief rendering)
+- Create: `components/dashboard/SelfProfileCard.tsx`
+- Create: `components/brief/SelfBriefView.tsx`
+
+- [ ] **Step 1: Write a failing component test for `SelfProfileCard`**
+
+Create `components/dashboard/__tests__/SelfProfileCard.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SelfProfileCard } from "../SelfProfileCard";
+
+describe("SelfProfileCard", () => {
+  it("renders the self company name and positioning", () => {
+    render(
+      <SelfProfileCard
+        self={{
+          id: "self_1",
+          name: "Rival",
+          slug: "rival",
+          baseUrl: "https://rival.so",
+          intelligenceBrief: {
+            positioning_summary: "CI for devs",
+            icp_summary: "Devs",
+            pricing_summary: "OSS",
+            differentiators: ["Tabstack-powered"],
+            recent_signals: []
+          }
+        } as any}
+      />
+    );
+    expect(screen.getByText(/Your Profile/i)).toBeInTheDocument();
+    expect(screen.getByText("Rival")).toBeInTheDocument();
+    expect(screen.getByText(/CI for devs/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no brief has been generated", () => {
+    render(
+      <SelfProfileCard
+        self={{
+          id: "self_1",
+          name: "Rival",
+          slug: "rival",
+          baseUrl: "https://rival.so",
+          intelligenceBrief: null
+        } as any}
+      />
+    );
+    expect(screen.getByText(/not yet analyzed|no profile yet/i)).toBeInTheDocument();
+  });
+});
+```
+
+If `@testing-library/react` is not yet installed in the project, install it as a devDependency. Check `package.json` first; if not present, add it with:
+
+```bash
+npm install --save-dev @testing-library/react @testing-library/jest-dom jsdom
+```
+
+And update `vitest.config.ts` to use the `jsdom` environment for React component tests. If component tests aren't yet a pattern in this repo, skip the React tests and manually verify instead — record the skip in the commit message.
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+npm run test -- SelfProfileCard
+```
+
+Expected: FAIL (component not found).
+
+- [ ] **Step 3: Create `components/dashboard/SelfProfileCard.tsx`**
+
+```tsx
+import Link from "next/link";
+import type { Competitor } from "@prisma/client";
+
+type SelfBrief = {
+  positioning_summary?: string;
+  icp_summary?: string;
+  pricing_summary?: string;
+  differentiators?: string[];
+  recent_signals?: string[];
+};
+
+function isSelfBrief(value: unknown): value is SelfBrief {
+  return typeof value === "object" && value !== null;
+}
+
+export function SelfProfileCard({ self }: { self: Competitor }) {
+  const brief = isSelfBrief(self.intelligenceBrief) ? (self.intelligenceBrief as SelfBrief) : null;
+
+  return (
+    <section className="self-profile-card">
+      <div className="self-profile-card__header">
+        <h2>Your Profile</h2>
+        <Link href={`/${self.slug}`} className="self-profile-card__link">
+          View details →
+        </Link>
+      </div>
+      <div className="self-profile-card__body">
+        <h3>{self.name}</h3>
+        {brief?.positioning_summary ? (
+          <p className="self-profile-card__positioning">{brief.positioning_summary}</p>
+        ) : (
+          <p className="self-profile-card__empty">
+            Not yet analyzed — self-profile will populate on the next scan cycle.
+          </p>
+        )}
+        {brief?.icp_summary && (
+          <p className="self-profile-card__icp"><strong>ICP:</strong> {brief.icp_summary}</p>
+        )}
+        {brief?.pricing_summary && (
+          <p className="self-profile-card__pricing"><strong>Pricing:</strong> {brief.pricing_summary}</p>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Add styles in `app/globals.css`**
+
+Append:
+
+```css
+.self-profile-card {
+  border: 1px solid var(--border-subtle, #e5e5e5);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+  background: var(--surface-1, #fafafa);
+}
+.self-profile-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+.self-profile-card__header h2 {
+  margin: 0;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #666);
+}
+.self-profile-card__link {
+  font-size: 0.875rem;
+}
+.self-profile-card__body h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+.self-profile-card__positioning { margin: 0 0 0.5rem; }
+.self-profile-card__icp,
+.self-profile-card__pricing { margin: 0.25rem 0; font-size: 0.9rem; color: var(--text-secondary, #444); }
+.self-profile-card__empty { color: var(--text-muted, #666); font-style: italic; }
+```
+
+(Match variable names to what already exists in `app/globals.css`. If those variables don't exist, use direct values.)
+
+- [ ] **Step 5: Wire `SelfProfileCard` into `app/page.tsx`**
+
+At the top, import:
+
+```ts
+import { SelfProfileCard } from "@/components/dashboard/SelfProfileCard";
+import { getSelfCompetitor } from "@/lib/db/competitors";
+```
+
+In `loadDashboardData` (or wherever the page fetches data), also fetch self:
+
+```ts
+const [competitors, self] = await Promise.all([
+  prisma.competitor.findMany({ where: { isSelf: false }, orderBy: { name: "asc" } }),
+  getSelfCompetitor()
+]);
+```
+
+Pass `self` down to the page component. In the JSX, above the existing `<ThreatMatrix>` / `<IntelFeed>` render:
+
+```tsx
+{self && <SelfProfileCard self={self} />}
+```
+
+- [ ] **Step 6: Create `components/brief/SelfBriefView.tsx`**
+
+```tsx
+type SelfBrief = {
+  positioning_summary?: string;
+  icp_summary?: string;
+  pricing_summary?: string;
+  differentiators?: string[];
+  recent_signals?: string[];
+};
+
+export function SelfBriefView({ brief }: { brief: SelfBrief }) {
+  return (
+    <div className="self-brief">
+      {brief.positioning_summary && (
+        <section>
+          <h3>Positioning</h3>
+          <p>{brief.positioning_summary}</p>
+        </section>
+      )}
+      {brief.icp_summary && (
+        <section>
+          <h3>ICP</h3>
+          <p>{brief.icp_summary}</p>
+        </section>
+      )}
+      {brief.pricing_summary && (
+        <section>
+          <h3>Pricing</h3>
+          <p>{brief.pricing_summary}</p>
+        </section>
+      )}
+      {brief.differentiators && brief.differentiators.length > 0 && (
+        <section>
+          <h3>Differentiators</h3>
+          <ul>
+            {brief.differentiators.map((item, i) => (<li key={i}>{item}</li>))}
+          </ul>
+        </section>
+      )}
+      {brief.recent_signals && brief.recent_signals.length > 0 && (
+        <section>
+          <h3>Recent Signals</h3>
+          <ul>
+            {brief.recent_signals.map((item, i) => (<li key={i}>{item}</li>))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Update `app/[slug]/page.tsx` to branch brief rendering and hide threat UI for self**
+
+Read the current file first. Where it renders the threat-level badge and the competitor brief, add a branch:
+
+```tsx
+{competitor.isSelf ? (
+  <SelfBriefView brief={competitor.intelligenceBrief as any} />
+) : (
+  // ...existing competitor brief rendering + threat badge
+)}
+```
+
+Import `SelfBriefView` at the top.
+
+- [ ] **Step 8: Run tests**
+
+```bash
+npm run test
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Typecheck and build**
+
+```bash
+npm run typecheck && npm run build
+```
+
+Expected: both PASS.
+
+- [ ] **Step 10: Manual verification**
+
+```bash
+npm run dev
+```
+
+With a self row seeded and a brief generated, verify:
+- `/` shows "Your Profile" card at top, self not in competitor list
+- `/<self-slug>` renders `SelfBriefView`, no threat badge, scan history link works
+- `/<competitor-slug>` unchanged behavior, threat badge present
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/page.tsx app/[slug]/page.tsx components/dashboard/SelfProfileCard.tsx components/brief/SelfBriefView.tsx app/globals.css components/dashboard/__tests__
+git commit -m "feat(ui): add Your Profile dashboard section and self brief view"
+```
+
+---
+
+## Task 12: Add `self` block to `rivals.config.json`
+
+**Files:**
+- Modify: `rivals.config.json`
+
+This is a project-specific content change. Only include pages that actually exist for Rival's own site today.
+
+- [ ] **Step 1: Add the self block**
+
+Open `rivals.config.json`. Above the `"competitors"` array, insert:
+
+```json
+{
+  "self": {
+    "name": "Rival",
+    "slug": "rival",
+    "url": "https://rival.so",
+    "pages": [
+      { "label": "Homepage", "url": "https://rival.so", "type": "homepage" }
+    ]
+  },
+  "competitors": [ ... existing ... ]
+}
+```
+
+Start with just the homepage. Add pricing / changelog / blog / about / github / docs / social / careers as they become real URLs on the Rival site. Do not add URLs that 404 — the scanner will log noise.
+
+- [ ] **Step 2: Local seed + bootstrap dry run**
+
+With a local database:
+
+```bash
+npm run db:seed
+npm run bootstrap-new
+```
+
+Expected: a `Rival` row is inserted with `is_self=true`, homepage scan runs, self brief generates.
+
+- [ ] **Step 3: Verify self-brief is present**
+
+```bash
+npx prisma studio
+```
+
+Navigate to `competitors`. Confirm the Rival row has `is_self = true`, `intelligence_brief` populated with the self-profile shape.
+
+- [ ] **Step 4: Verify self-context injection end-to-end**
+
+Run a single competitor scan manually (choose one existing competitor):
+
+```bash
+# via the /api/scan route, or tsx script, or trigger cron locally
+```
+
+Confirm in `api_logs` that the subsequent `generate` call's instructions include the "CONTEXT — about the user's own company" block. (If the logger doesn't store the full prompt, add a debug `console.log` in `generateBrief` for this verification step and remove before committing.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rivals.config.json
+git commit -m "feat(config): add Rival self entry to rivals.config.json"
+```
+
+---
+
+## Task 13: End-to-end validation and PR
+
+- [ ] **Step 1: Full test suite + coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: PASS, coverage ≥ 80% per CLAUDE.md.
+
+- [ ] **Step 2: Typecheck + build**
+
+```bash
+npm run typecheck && npm run build
+```
+
+Expected: both PASS.
+
+- [ ] **Step 3: Update DX notes**
+
+Per CLAUDE.md, any change in `lib/tabstack/*.ts` must update `notes-local/tabstack-dx-notes.md`. Append entries about:
+
+- Injecting operator/self context into `/generate` instructions (DX observation: was the string prepend ergonomic? did the 800-char cap feel right?)
+- Reusing `/generate` with a second schema (`SELF_PROFILE_SCHEMA`) alongside `BRIEF_SCHEMA` (DX observation: schema structuring overhead? readability of the calling code?)
+- Prepending context to a natural-language `/research` `query` (DX observation: was that the right surface area, or would a separate system-prompt-equivalent be cleaner?)
+
+- [ ] **Step 4: Commit DX notes**
+
+```bash
+git add notes-local/tabstack-dx-notes.md
+git commit -m "docs(dx): self-profile DX observations for Tabstack integration"
+```
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin feat/self-profile-spec
+gh pr create --title "feat: self-profile for personalized competitive context" --body "$(cat <<'EOF'
+## Summary
+- Add `isSelf` flag to `Competitor` model (partial unique index) so the user's own company rides the existing scanner/cron/brief pipeline
+- Add `SELF_PROFILE_SCHEMA` + `generateSelfProfile` in `lib/tabstack/generate.ts` and `generateSelfBrief` in `lib/brief.ts` for self-analysis
+- Add `buildSelfContext()` helper; inject into `generateBrief` and `runResearch` so every competitor-facing AI call gets context about the user's company
+- Filter self from competitor listings; add "Your Profile" dashboard section and self-specific detail-page brief view
+- Config: new top-level `self` block in `rivals.config.json`, seeded the same way as competitors
+
+See spec: `docs/superpowers/specs/2026-04-21-self-profile-design.md`
+
+## Test plan
+- [ ] `npm run test:coverage` passes with ≥80% coverage
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` passes
+- [ ] Local seed + bootstrap produces a self row with is_self=true and a self-profile brief
+- [ ] `/` dashboard renders "Your Profile" section; self is NOT in the competitor grid
+- [ ] A competitor brief generated AFTER the self brief exists contains self-context in its `/generate` instructions (verify via api_logs or temporary debug log)
+- [ ] Demo scan path (`isDemo: true`) does NOT include self-context in its prompts
+EOF
+)"
+```
+
+---
+
+## Self-Review (complete before handoff)
+
+- [ ] **Spec coverage:** Every section of the spec is covered by at least one task above. Specifically:
+  - Config shape (spec §Config) → Task 2 + Task 12
+  - DB change (spec §Database) → Task 1
+  - Seed (spec §Seed) → Task 2
+  - Bootstrap + cron (spec §Bootstrap and Cron, §Branching) → Task 5
+  - Self brief (spec §Self Brief) → Tasks 3, 4
+  - Context injection (spec §Context Injection, §Injection Sites, §Demo path) → Tasks 6, 7, 8
+  - API (spec §API Routes) → Tasks 9, 10
+  - UI (spec §Dashboard UI) → Task 11
+  - Rollout + project config (spec §Rollout) → Task 12
+- [ ] **No placeholders** — every step has actual code, exact file paths, exact commands
+- [ ] **Type consistency** — `isSelf` (camelCase TS) / `is_self` (snake_case SQL column) used consistently throughout
+- [ ] **Function name consistency** — `generateSelfProfile` (Tabstack layer), `generateSelfBrief` (orchestrator), `buildSelfContext` (injection helper) used identically in every task
+- [ ] **Test coverage** — every new function has at least one unit test with a failing-test-first step
+- [ ] **Demo guard** — `buildSelfContext({ isDemo })` is tested and enforced at every injection site

--- a/docs/superpowers/specs/2026-04-21-self-profile-design.md
+++ b/docs/superpowers/specs/2026-04-21-self-profile-design.md
@@ -1,0 +1,223 @@
+# Self-Profile Design
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Goal
+
+Give Rival context about the user's own company so every AI surface (briefs, threat scoring, deep dives, future compare) produces recommendations *relative to you* instead of generic competitor commentary.
+
+Today, briefs read like analyst observations. With self-context injected, they read like threat assessments addressed to a specific product with a specific ICP and pricing model.
+
+## Principle
+
+Self is treated exactly like a competitor. Same scanner, same page types, same cron, same brief infrastructure. The only differences are:
+
+1. A boolean flag distinguishing self from competitors.
+2. A different prompt and schema for self's own brief (self-analysis, not competitive analysis).
+3. Self's latest brief + manual data is injected as context into every AI call that targets a competitor.
+4. Self is filtered out of the competitor grid and shown in its own dashboard section.
+
+## Config
+
+`rivals.config.json` gets a top-level `self` block with the same shape as a competitor entry:
+
+```json
+{
+  "self": {
+    "name": "Rival",
+    "slug": "rival",
+    "url": "https://rival.so",
+    "pages": [
+      { "label": "Homepage", "url": "https://rival.so", "type": "homepage" },
+      { "label": "Pricing", "url": "https://rival.so/pricing", "type": "pricing", "geo_target": "US" },
+      { "label": "Changelog", "url": "https://rival.so/changelog", "type": "changelog" },
+      { "label": "Careers", "url": "https://rival.so/careers", "type": "careers" },
+      { "label": "GitHub", "url": "https://github.com/tessak22/rival", "type": "github" },
+      { "label": "Docs", "url": "https://rival.so/docs", "type": "docs" },
+      { "label": "Blog", "url": "https://rival.so/blog", "type": "blog" },
+      { "label": "About", "url": "https://rival.so/about", "type": "profile" },
+      { "label": "Twitter/X", "url": "https://x.com/rivalapp", "type": "social" }
+    ]
+  },
+  "competitors": [ ... ]
+}
+```
+
+All existing page types are supported. `manual` override works the same as for competitors.
+
+## Database
+
+Reuse the `Competitor` model. Add one column:
+
+```prisma
+model Competitor {
+  // ...existing fields...
+  isSelf Boolean @default(false) @map("is_self")
+}
+```
+
+Partial unique index in a migration enforces at most one self row:
+
+```sql
+CREATE UNIQUE INDEX competitors_is_self_unique
+  ON competitors (is_self) WHERE is_self = true;
+```
+
+No new table. No new model for pages, scans, briefs, or logs — self uses the existing ones via its `Competitor.id`.
+
+## Seed
+
+`scripts/seed.ts` is extended to read `config.self` and upsert it as a Competitor row with `isSelf: true`. Same upsert logic as competitors, keyed by `slug`. If `config.self` is absent, nothing happens (backward compatible — existing deployments without a self entry keep working until the user adds one).
+
+## Bootstrap and Cron
+
+No changes to `scripts/bootstrap-new-competitors.ts` or `lib/run-scans.ts`. Both iterate `prisma.competitor.findMany({ include: { pages: true } })`, which naturally includes self. Self scans on the same schedule and through the same pipeline as competitors.
+
+## Self Brief
+
+A new brief generator is added for self, with a schema designed for downstream context injection (not competitive analysis).
+
+**New function:** `generateSelfBrief(competitorId)` in `lib/brief.ts`, calling a new `generateSelfProfile` in `lib/tabstack/generate.ts`.
+
+**New schema:** `SELF_PROFILE_SCHEMA` with fields:
+- `positioning_summary` — 1–2 sentences: who you are, what you sell
+- `icp_summary` — 1–2 sentences: who you serve
+- `pricing_summary` — brief description of monetization model (free / paid / freemium / OSS + paid / etc.)
+- `differentiators` — 3–5 bullets of what makes you distinct
+- `recent_signals` — 3–5 bullets of recent changes visible from changelog, blog, careers
+
+This output is stored in the same `intelligenceBrief` JSON column as competitor briefs. `threatLevel` stays null for self.
+
+Rationale for a different schema: the competitor brief schema (`positioning_opportunity`, `threat_level`, `watch_list`) describes how to evaluate *someone else*. Forcing it onto self produces awkward output. A purpose-built self schema doubles as the context-injection string.
+
+## Branching in `run-scans.ts` and Bootstrap
+
+`lib/run-scans.ts` and `scripts/bootstrap-new-competitors.ts` branch on `competitor.isSelf`:
+
+```ts
+if (competitor.isSelf) {
+  await generateSelfBrief(competitor.id, briefNocache);
+} else {
+  await generateCompetitorBrief(competitor.id, briefNocache);
+}
+```
+
+## Context Injection
+
+**New module:** `lib/context/self-context.ts`
+
+```ts
+export async function buildSelfContext(): Promise<string | null>
+```
+
+Loads the self row. If no self row exists or no brief has been generated yet, returns `null` (callers pass through without injection — backward compatible for fresh installs).
+
+Returns a compact string built from:
+- `positioning_summary`
+- `icp_summary`
+- `pricing_summary`
+- `differentiators` (joined)
+- `manual_data` (if present, merged in — user overrides take precedence)
+
+Merge strategy: any top-level key in `manual_data` matching a brief field name overrides the brief value for that key. Extra keys in `manual_data` (not in the brief schema) are appended as an additional "User notes" section. This lets the user both correct extraction mistakes and add facts the scanner can't see (e.g., "we just signed an enterprise deal with X").
+
+Capped at ~800 chars so it doesn't dominate the downstream prompt.
+
+Format:
+```
+CONTEXT — about the user's own company (who this brief is for):
+Name: Rival
+Positioning: ...
+ICP: ...
+Pricing: ...
+What makes us distinct: ...
+Use this to frame recommendations, threat levels, and opportunities relative to THIS company specifically. Do not echo this context in the output.
+```
+
+## Injection Sites
+
+Every AI call that evaluates a competitor prepends the self-context to its instructions/query.
+
+| Call | File | Injection |
+|---|---|---|
+| `generateBrief` (competitor brief) | `lib/tabstack/generate.ts:238` | Prepend self-context block to `instructions` before `Additional competitor context:` |
+| `runResearch` (deep dive) | `lib/tabstack/research.ts:180` | Prepend self-context block to `query` |
+| Future compare | TBD | Same injection pattern |
+
+`generateSelfProfile` (the self-brief call itself) does NOT inject self-context — it's analyzing self from scratch, not comparing.
+
+The injection is additive: if `buildSelfContext()` returns null (no self configured, or self brief not yet generated), the prompts fall through to current behavior. No regressions for deployments that haven't configured self.
+
+**Demo path:** self-context is NOT injected into demo scans. The demo lets a user paste any URL for a one-shot scan — that URL is not *their* product, and injecting the operator's self-profile would poison the output. The demo code path calls `generateBrief` / `runResearch` with `isDemo: true`; the injection helper skips when that flag is set.
+
+## Dashboard UI
+
+**Competitor grid (`app/page.tsx`):** filter out `isSelf = true` so self doesn't appear alongside competitors.
+
+**New section at top of dashboard:** "Your Profile" — renders the self competitor using the same card component, minus the threat-level badge (threat doesn't apply to self).
+
+**Detail page (`app/[slug]/page.tsx`):** works unchanged for self (slug resolves normally). Threat-level UI is hidden when `isSelf` is true. Brief rendering branches on schema shape — self briefs render the self-profile fields; competitor briefs render the competitive fields. Both use the same wrapper layout.
+
+**Scan history (`app/[slug]/history/page.tsx`):** works unchanged. Self's scan history is browsable the same way.
+
+## API Routes
+
+`app/api/competitors/route.ts` (and any other list endpoint) — filter out `isSelf` from the competitors list response. Add an optional `self` field in the response for UI consumption.
+
+`app/api/self/route.ts` (new, optional) — returns the self row for the dashboard's "Your Profile" section. Read-only.
+
+No mutation endpoints. All changes flow through `rivals.config.json`, consistent with the competitor pattern.
+
+## Experience Logging
+
+`api_logs` already captures `competitor_id` — self's AI calls are logged the same way, distinguishable by `competitor_id` pointing at the self row. No schema changes.
+
+## Files Touched
+
+| File | Action | Purpose |
+|---|---|---|
+| `prisma/schema.prisma` | Modify | Add `isSelf` to `Competitor` |
+| `prisma/migrations/…_add_is_self/migration.sql` | Create | Column + partial unique index |
+| `rivals.config.json` | Modify | Add `self` block (project-specific content) |
+| `scripts/seed.ts` | Modify | Upsert self from config |
+| `lib/tabstack/generate.ts` | Modify | Add `SELF_PROFILE_SCHEMA` + `generateSelfProfile`; inject self-context in `generateBrief` |
+| `lib/tabstack/research.ts` | Modify | Inject self-context in `runResearch` query |
+| `lib/brief.ts` | Modify | Add `generateSelfBrief` |
+| `lib/context/self-context.ts` | Create | `buildSelfContext()` helper |
+| `lib/run-scans.ts` | Modify | Branch on `isSelf` for brief gen |
+| `scripts/bootstrap-new-competitors.ts` | Modify | Branch on `isSelf` for brief gen |
+| `app/page.tsx` | Modify | Filter self from grid; add "Your Profile" section |
+| `app/[slug]/page.tsx` | Modify | Branch brief rendering + hide threat UI for self |
+| `app/api/competitors/route.ts` | Modify | Filter self from list response |
+| `app/api/self/route.ts` | Create (optional) | Dedicated self read endpoint |
+| DX notes: `notes-local/tabstack-dx-notes.md` | Modify | Record any DX findings from context injection work |
+
+## Testing
+
+- Unit: `buildSelfContext` with (a) no self row, (b) self row with no brief, (c) full self row with brief + manual_data. Expect graceful null / partial / full output.
+- Unit: `generateSelfBrief` with mocked Tabstack response — verifies schema parsing.
+- Unit: `generateBrief` and `runResearch` — verify self-context is prepended when available, omitted when null.
+- Integration: end-to-end bootstrap run on a fresh DB with a `self` block in config — self is seeded, scanned, self-brief generated, and subsequent competitor briefs include self-context in their prompts (verifiable via `api_logs` url/prompt snapshot if we capture it, or by asserting the `generateBrief` call site receives a non-null context arg).
+- UI: self does not appear in the competitor grid; "Your Profile" section renders; detail page hides threat badge for self.
+
+## Out of Scope
+
+- Settings UI for editing self-profile in-browser (future, requires rethinking config-as-source-of-truth).
+- Multi-tenant support (Rival is single-tenant by design).
+- Historical diffing of self-brief output (nice-to-have).
+- Compare page (separate feature, but designed to consume self-context the same way).
+- Notifications triggered by self scan changes (future — probably undesirable since users don't need to be alerted about their own site changing).
+
+## Open Questions
+
+None at design time. The config-driven pattern and Competitor-row reuse avoid new primitives.
+
+## Rollout
+
+1. Ship schema + seed + config shape — deploy to production with no `self` block configured yet (all existing behavior unchanged).
+2. Add `self` block to production `rivals.config.json`. Bootstrap runs on next deploy, scans self, generates self-brief.
+3. Ship context injection changes. Next cron cycle produces competitor briefs with self-context included.
+4. Ship UI changes. Self appears in its own dashboard section.
+
+Each step is independently deployable and reversible.

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -342,6 +342,35 @@ describe("generateSelfBrief", () => {
     await expect(generateSelfBrief("cmp_1")).rejects.toThrow(/no recent scans/i);
   });
 
+  it("throws when only stale scans exist", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([makeStaleScan()]);
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await expect(generateSelfBrief("cmp_1")).rejects.toThrow(/no recent scans/i);
+  });
+
+  it("throws when the target competitor is not the self row", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: false });
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await expect(generateSelfBrief("cmp_1")).rejects.toThrow(/not the self row/i);
+  });
+
+  it("forwards baseUrl and nocache to generateSelfProfile", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await generateSelfBrief("cmp_1", false);
+
+    expect(generateSelfProfileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://acme.com",
+        nocache: false
+      })
+    );
+  });
+
   it("throws when the competitor is not found", async () => {
     competitorFindUniqueMock.mockResolvedValue(null);
     const { generateSelfBrief } = await import("@/lib/brief");

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -99,6 +99,13 @@ describe("generateCompetitorBrief", () => {
     expect(generateBriefMock).not.toHaveBeenCalled();
   });
 
+  it("throws when the target competitor is the self row", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+    const { generateCompetitorBrief } = await import("@/lib/brief");
+    await expect(generateCompetitorBrief("cmp_1")).rejects.toThrow(/self row/i);
+  });
+
   it("throws when no recent scans are available", async () => {
     scanFindManyMock.mockResolvedValueOnce([makeStaleScan()]);
     const { generateCompetitorBrief } = await import("@/lib/brief");

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -1,24 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  competitorFindUniqueMock,
-  scanFindManyMock,
-  competitorUpdateMock,
-  generateBriefMock,
-  generateSelfProfileMock
-} = vi.hoisted(() => ({
-  competitorFindUniqueMock: vi.fn(),
-  scanFindManyMock: vi.fn(),
-  competitorUpdateMock: vi.fn(),
-  generateBriefMock: vi.fn(),
-  generateSelfProfileMock: vi.fn().mockResolvedValue({
-    positioning_summary: "Rival is a competitive intelligence tool.",
-    icp_summary: "Developers tracking competitors.",
-    pricing_summary: "Open source, self-hosted.",
-    differentiators: ["Powered by Tabstack", "Open source"],
-    recent_signals: ["Added self-profile feature"]
-  })
-}));
+const { competitorFindUniqueMock, scanFindManyMock, competitorUpdateMock, generateBriefMock, generateSelfProfileMock } =
+  vi.hoisted(() => ({
+    competitorFindUniqueMock: vi.fn(),
+    scanFindManyMock: vi.fn(),
+    competitorUpdateMock: vi.fn(),
+    generateBriefMock: vi.fn(),
+    generateSelfProfileMock: vi.fn().mockResolvedValue({
+      positioning_summary: "Rival is a competitive intelligence tool.",
+      icp_summary: "Developers tracking competitors.",
+      pricing_summary: "Open source, self-hosted.",
+      differentiators: ["Powered by Tabstack", "Open source"],
+      recent_signals: ["Added self-profile feature"]
+    })
+  }));
 
 vi.mock("@/lib/db/client", () => ({
   prisma: {

--- a/lib/__tests__/brief.test.ts
+++ b/lib/__tests__/brief.test.ts
@@ -1,10 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { competitorFindUniqueMock, scanFindManyMock, competitorUpdateMock, generateBriefMock } = vi.hoisted(() => ({
+const {
+  competitorFindUniqueMock,
+  scanFindManyMock,
+  competitorUpdateMock,
+  generateBriefMock,
+  generateSelfProfileMock
+} = vi.hoisted(() => ({
   competitorFindUniqueMock: vi.fn(),
   scanFindManyMock: vi.fn(),
   competitorUpdateMock: vi.fn(),
-  generateBriefMock: vi.fn()
+  generateBriefMock: vi.fn(),
+  generateSelfProfileMock: vi.fn().mockResolvedValue({
+    positioning_summary: "Rival is a competitive intelligence tool.",
+    icp_summary: "Developers tracking competitors.",
+    pricing_summary: "Open source, self-hosted.",
+    differentiators: ["Powered by Tabstack", "Open source"],
+    recent_signals: ["Added self-profile feature"]
+  })
 }));
 
 vi.mock("@/lib/db/client", () => ({
@@ -20,7 +33,8 @@ vi.mock("@/lib/db/client", () => ({
 }));
 
 vi.mock("@/lib/tabstack/generate", () => ({
-  generateBrief: generateBriefMock
+  generateBrief: generateBriefMock,
+  generateSelfProfile: generateSelfProfileMock
 }));
 
 const COMPETITOR = {
@@ -275,5 +289,82 @@ describe("generateCompetitorBrief", () => {
       const data = (lastCall[0] as { data: { threatLevel: string } }).data;
       expect(data.threatLevel).toBe(level);
     }
+  });
+});
+
+describe("generateSelfBrief", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    competitorFindUniqueMock.mockReset();
+    scanFindManyMock.mockReset();
+    competitorUpdateMock.mockReset();
+    generateSelfProfileMock.mockReset();
+    // Re-arm the default resolved value after reset:
+    generateSelfProfileMock.mockResolvedValue({
+      positioning_summary: "Rival is a competitive intelligence tool.",
+      icp_summary: "Developers tracking competitors.",
+      pricing_summary: "Open source, self-hosted.",
+      differentiators: ["Powered by Tabstack", "Open source"],
+      recent_signals: ["Added self-profile feature"]
+    });
+  });
+
+  it("stores the self-profile output on the self Competitor row with threatLevel null", async () => {
+    competitorFindUniqueMock.mockResolvedValue({
+      ...COMPETITOR,
+      isSelf: true
+    });
+    scanFindManyMock.mockResolvedValue([makeRecentScan()]);
+
+    const { generateSelfBrief } = await import("@/lib/brief");
+    const payload = await generateSelfBrief("cmp_1", true);
+
+    expect(payload).toMatchObject({
+      positioning_summary: expect.any(String),
+      icp_summary: expect.any(String),
+      pricing_summary: expect.any(String)
+    });
+    expect(competitorUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "cmp_1" },
+        data: expect.objectContaining({
+          threatLevel: null,
+          intelligenceBrief: expect.any(Object)
+        })
+      })
+    );
+  });
+
+  it("throws when no recent scans exist", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([]);
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await expect(generateSelfBrief("cmp_1")).rejects.toThrow(/no recent scans/i);
+  });
+
+  it("throws when the competitor is not found", async () => {
+    competitorFindUniqueMock.mockResolvedValue(null);
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await expect(generateSelfBrief("nope")).rejects.toThrow(/not found/i);
+  });
+
+  it("includes ALL page types in the self-profile context (no filter)", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ ...COMPETITOR, isSelf: true });
+    scanFindManyMock.mockResolvedValue([
+      makeRecentScan({ id: "s_changelog", pageId: "p_changelog", page: { type: "changelog", label: "Changelog" } }),
+      makeRecentScan({ id: "s_docs", pageId: "p_docs", page: { type: "docs", label: "Docs" } }),
+      makeRecentScan({ id: "s_social", pageId: "p_social", page: { type: "social", label: "Twitter" } }),
+      makeRecentScan({ id: "s_home", pageId: "p_home", page: { type: "homepage", label: "Home" } })
+    ]);
+
+    const { generateSelfBrief } = await import("@/lib/brief");
+    await generateSelfBrief("cmp_1", true);
+
+    const call = generateSelfProfileMock.mock.calls[0][0];
+    const context = call.contextData as string;
+    expect(context).toContain("changelog");
+    expect(context).toContain("docs");
+    expect(context).toContain("social");
+    expect(context).toContain("homepage");
   });
 });

--- a/lib/__tests__/run-scans.test.ts
+++ b/lib/__tests__/run-scans.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/brief", () => ({
 
 describe("runScans", () => {
   beforeEach(() => {
+    vi.resetModules();
     competitorFindManyMock.mockReset();
     demoIpLockDeleteManyMock.mockReset().mockResolvedValue({ count: 0 });
     scanPageMock.mockReset().mockResolvedValue({});

--- a/lib/__tests__/run-scans.test.ts
+++ b/lib/__tests__/run-scans.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  competitorFindManyMock,
+  demoIpLockDeleteManyMock,
+  scanPageMock,
+  generateCompetitorBriefMock,
+  generateSelfBriefMock
+} = vi.hoisted(() => ({
+  competitorFindManyMock: vi.fn(),
+  demoIpLockDeleteManyMock: vi.fn().mockResolvedValue({ count: 0 }),
+  scanPageMock: vi.fn().mockResolvedValue({}),
+  generateCompetitorBriefMock: vi.fn().mockResolvedValue({ threat_level: "Medium" }),
+  generateSelfBriefMock: vi.fn().mockResolvedValue({ positioning_summary: "x" })
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: { findMany: competitorFindManyMock },
+    demoIpLock: { deleteMany: demoIpLockDeleteManyMock }
+  }
+}));
+
+vi.mock("@/lib/scanner", () => ({
+  scanPage: scanPageMock
+}));
+
+vi.mock("@/lib/brief", () => ({
+  generateCompetitorBrief: generateCompetitorBriefMock,
+  generateSelfBrief: generateSelfBriefMock
+}));
+
+describe("runScans", () => {
+  beforeEach(() => {
+    competitorFindManyMock.mockReset();
+    demoIpLockDeleteManyMock.mockReset().mockResolvedValue({ count: 0 });
+    scanPageMock.mockReset().mockResolvedValue({});
+    generateCompetitorBriefMock.mockReset().mockResolvedValue({ threat_level: "Medium" });
+    generateSelfBriefMock.mockReset().mockResolvedValue({ positioning_summary: "x" });
+  });
+
+  it("calls generateSelfBrief for isSelf rows and generateCompetitorBrief for others", async () => {
+    competitorFindManyMock.mockResolvedValue([
+      { id: "cmp_a", isSelf: false, pages: [{ id: "pg_a", label: "Home", url: "https://a.co", type: "homepage", geoTarget: null }] },
+      { id: "cmp_self", isSelf: true, pages: [{ id: "pg_s", label: "Home", url: "https://rival.so", type: "homepage", geoTarget: null }] }
+    ]);
+
+    const { runScans } = await import("@/lib/run-scans");
+    await runScans();
+
+    expect(generateCompetitorBriefMock).toHaveBeenCalledTimes(1);
+    expect(generateCompetitorBriefMock).toHaveBeenCalledWith("cmp_a", expect.any(Boolean));
+    expect(generateSelfBriefMock).toHaveBeenCalledTimes(1);
+    expect(generateSelfBriefMock).toHaveBeenCalledWith("cmp_self", expect.any(Boolean));
+  });
+
+  it("marks briefGenerated=true for self when generateSelfBrief succeeds", async () => {
+    competitorFindManyMock.mockResolvedValue([
+      { id: "cmp_self", isSelf: true, pages: [] }
+    ]);
+
+    const { runScans } = await import("@/lib/run-scans");
+    const result = await runScans();
+
+    const selfSummary = result.summary.find((s) => s.competitorId === "cmp_self");
+    expect(selfSummary?.briefGenerated).toBe(true);
+    expect(selfSummary?.errors).toHaveLength(0);
+  });
+
+  it("records an error on self row when generateSelfBrief fails", async () => {
+    generateSelfBriefMock.mockRejectedValue(new Error("tabstack timeout"));
+    competitorFindManyMock.mockResolvedValue([
+      { id: "cmp_self", isSelf: true, pages: [] }
+    ]);
+
+    const { runScans } = await import("@/lib/run-scans");
+    const result = await runScans();
+
+    const selfSummary = result.summary.find((s) => s.competitorId === "cmp_self");
+    expect(selfSummary?.briefGenerated).toBe(false);
+    expect(selfSummary?.errors[0]).toMatch(/tabstack timeout/);
+  });
+});

--- a/lib/__tests__/run-scans.test.ts
+++ b/lib/__tests__/run-scans.test.ts
@@ -42,8 +42,16 @@ describe("runScans", () => {
 
   it("calls generateSelfBrief for isSelf rows and generateCompetitorBrief for others", async () => {
     competitorFindManyMock.mockResolvedValue([
-      { id: "cmp_a", isSelf: false, pages: [{ id: "pg_a", label: "Home", url: "https://a.co", type: "homepage", geoTarget: null }] },
-      { id: "cmp_self", isSelf: true, pages: [{ id: "pg_s", label: "Home", url: "https://rival.so", type: "homepage", geoTarget: null }] }
+      {
+        id: "cmp_a",
+        isSelf: false,
+        pages: [{ id: "pg_a", label: "Home", url: "https://a.co", type: "homepage", geoTarget: null }]
+      },
+      {
+        id: "cmp_self",
+        isSelf: true,
+        pages: [{ id: "pg_s", label: "Home", url: "https://rival.so", type: "homepage", geoTarget: null }]
+      }
     ]);
 
     const { runScans } = await import("@/lib/run-scans");
@@ -56,9 +64,7 @@ describe("runScans", () => {
   });
 
   it("marks briefGenerated=true for self when generateSelfBrief succeeds", async () => {
-    competitorFindManyMock.mockResolvedValue([
-      { id: "cmp_self", isSelf: true, pages: [] }
-    ]);
+    competitorFindManyMock.mockResolvedValue([{ id: "cmp_self", isSelf: true, pages: [] }]);
 
     const { runScans } = await import("@/lib/run-scans");
     const result = await runScans();
@@ -70,9 +76,7 @@ describe("runScans", () => {
 
   it("records an error on self row when generateSelfBrief fails", async () => {
     generateSelfBriefMock.mockRejectedValue(new Error("tabstack timeout"));
-    competitorFindManyMock.mockResolvedValue([
-      { id: "cmp_self", isSelf: true, pages: [] }
-    ]);
+    competitorFindManyMock.mockResolvedValue([{ id: "cmp_self", isSelf: true, pages: [] }]);
 
     const { runScans } = await import("@/lib/run-scans");
     const result = await runScans();

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -150,6 +150,10 @@ export async function generateCompetitorBrief(competitorId: string, nocache = tr
     throw new Error("Competitor not found");
   }
 
+  if (competitor.isSelf) {
+    throw new Error(`Competitor ${competitorId} is the self row; use generateSelfBrief instead`);
+  }
+
   const staleThreshold = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7); // 7 days
   const scans = await prisma.scan.findMany({
     where: { page: { competitorId } },

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -82,6 +82,10 @@ export async function generateSelfBrief(competitorId: string, nocache = true) {
     throw new Error("Competitor not found");
   }
 
+  if (!competitor.isSelf) {
+    throw new Error(`Competitor ${competitorId} is not the self row`);
+  }
+
   const staleThreshold = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7);
   const scans = await prisma.scan.findMany({
     where: { page: { competitorId } },

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -22,7 +22,7 @@
  */
 
 import { prisma } from "@/lib/db/client";
-import { generateBrief } from "@/lib/tabstack/generate";
+import { generateBrief, generateSelfProfile } from "@/lib/tabstack/generate";
 import { isPlainObject, stringifyUnknown } from "@/lib/utils/types";
 import { Prisma } from "@prisma/client";
 
@@ -70,6 +70,70 @@ function toJsonValue(value: unknown): Prisma.InputJsonValue | Prisma.NullableJso
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
   if (Array.isArray(value) || isPlainObject(value)) return value as Prisma.InputJsonValue;
   return stringifyUnknown(value);
+}
+
+export async function generateSelfBrief(competitorId: string, nocache = true) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { id: competitorId },
+    include: { pages: true }
+  });
+
+  if (!competitor) {
+    throw new Error("Competitor not found");
+  }
+
+  const staleThreshold = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7);
+  const scans = await prisma.scan.findMany({
+    where: { page: { competitorId } },
+    include: { page: true },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  const latestByPage = new Map<string, { pageType: string; pageLabel: string; result: unknown }>();
+  for (const scan of scans) {
+    if (latestByPage.has(scan.pageId)) continue;
+    if (scan.scannedAt < staleThreshold) continue;
+    latestByPage.set(scan.pageId, {
+      pageType: scan.page.type,
+      pageLabel: scan.page.label,
+      result: scan.markdownResult ?? scan.rawResult
+    });
+  }
+
+  if (latestByPage.size === 0) {
+    throw new Error("No recent scans available for self-profile generation");
+  }
+
+  // Self brief includes ALL page types. Unlike competitor briefs, we want every
+  // signal from the user's own surfaces so the injected context is maximally useful.
+  const contextData = JSON.stringify(
+    [...latestByPage.values()].map((scan) => ({
+      page_type: scan.pageType,
+      page_label: scan.pageLabel,
+      result: truncateResult(scan.result)
+    }))
+  );
+
+  const response = await generateSelfProfile({
+    competitorId,
+    url: competitor.baseUrl,
+    contextData,
+    effort: "low",
+    nocache
+  });
+
+  const payload = extractBriefPayload(response);
+
+  await prisma.competitor.update({
+    where: { id: competitorId },
+    data: {
+      intelligenceBrief: toJsonValue(payload),
+      threatLevel: null,
+      briefGeneratedAt: new Date()
+    }
+  });
+
+  return payload;
 }
 
 export async function generateCompetitorBrief(competitorId: string, nocache = true) {

--- a/lib/config/__tests__/rival-config.test.ts
+++ b/lib/config/__tests__/rival-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseRivalConfig } from "@/lib/config/rival-config";
+
+describe("parseRivalConfig", () => {
+  it("parses config without a self block", () => {
+    const result = parseRivalConfig({
+      competitors: [{ name: "Acme", slug: "acme", url: "https://a.co", pages: [] }]
+    });
+    expect(result.self).toBeNull();
+    expect(result.competitors).toHaveLength(1);
+  });
+
+  it("parses a self block identically to a competitor entry", () => {
+    const result = parseRivalConfig({
+      self: {
+        name: "Rival",
+        slug: "rival",
+        url: "https://rival.so",
+        pages: [{ label: "Home", url: "https://rival.so", type: "homepage" }]
+      },
+      competitors: []
+    });
+    expect(result.self).not.toBeNull();
+    expect(result.self?.slug).toBe("rival");
+    expect(result.self?.pages).toHaveLength(1);
+  });
+
+  it("rejects a self entry whose slug collides with a competitor slug", () => {
+    expect(() =>
+      parseRivalConfig({
+        self: { name: "Rival", slug: "acme", url: "https://rival.so", pages: [] },
+        competitors: [{ name: "Acme", slug: "acme", url: "https://a.co", pages: [] }]
+      })
+    ).toThrow(/slug.*collision|duplicate slug/i);
+  });
+});

--- a/lib/config/rival-config.ts
+++ b/lib/config/rival-config.ts
@@ -1,0 +1,38 @@
+export type RivalConfigEntry = {
+  name: string;
+  slug: string;
+  url: string;
+  manual?: Record<string, unknown> & { manual_last_updated?: string };
+  pages?: Array<{
+    label: string;
+    url: string;
+    type: string;
+    geo_target?: string;
+  }>;
+};
+
+export type ParsedRivalConfig = {
+  self: RivalConfigEntry | null;
+  competitors: RivalConfigEntry[];
+};
+
+type RawConfig = {
+  self?: RivalConfigEntry;
+  competitors?: RivalConfigEntry[];
+};
+
+export function parseRivalConfig(raw: RawConfig): ParsedRivalConfig {
+  const self = raw.self ?? null;
+  const competitors = raw.competitors ?? [];
+
+  if (self) {
+    const collision = competitors.find((c) => c.slug === self.slug);
+    if (collision) {
+      throw new Error(
+        `rivals.config.json: slug collision between self and competitor "${self.slug}". Choose a different slug for one of them.`
+      );
+    }
+  }
+
+  return { self, competitors };
+}

--- a/lib/context/__tests__/self-context.test.ts
+++ b/lib/context/__tests__/self-context.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { competitorFindFirstMock } = vi.hoisted(() => ({
+  competitorFindFirstMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: {
+      findFirst: competitorFindFirstMock
+    }
+  }
+}));
+
+describe("buildSelfContext", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    competitorFindFirstMock.mockReset();
+  });
+
+  it("returns null when no self row exists", async () => {
+    competitorFindFirstMock.mockResolvedValue(null);
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when self row has no intelligenceBrief", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: null,
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toBeNull();
+  });
+
+  it("returns a compact context string when brief is present", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "CI tool for devs",
+        icp_summary: "Developers tracking competitors",
+        pricing_summary: "Open source, self-hosted",
+        differentiators: ["Powered by Tabstack", "Open source"],
+        recent_signals: ["Added self-profile"]
+      },
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).not.toBeNull();
+    expect(result).toContain("Rival");
+    expect(result).toContain("CI tool for devs");
+    expect(result).toContain("Powered by Tabstack");
+    expect(result!.length).toBeLessThanOrEqual(1200); // 800 payload cap + framing overhead
+  });
+
+  it("lets manual_data override brief fields", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "OLD positioning",
+        icp_summary: "Devs",
+        pricing_summary: "Free",
+        differentiators: [],
+        recent_signals: []
+      },
+      manualData: { positioning_summary: "NEW positioning" }
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toContain("NEW positioning");
+    expect(result).not.toContain("OLD positioning");
+  });
+
+  it("surfaces extra manual_data keys as a User notes section", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "x",
+        icp_summary: "x",
+        pricing_summary: "x",
+        differentiators: [],
+        recent_signals: []
+      },
+      manualData: { extra_fact: "signed Acme deal" }
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toContain("User notes");
+    expect(result).toContain("signed Acme deal");
+  });
+
+  it("returns null when isDemo is true even with a full self row", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "x",
+        icp_summary: "x",
+        pricing_summary: "x",
+        differentiators: [],
+        recent_signals: []
+      },
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext({ isDemo: true });
+    expect(result).toBeNull();
+  });
+});

--- a/lib/context/__tests__/self-context.test.ts
+++ b/lib/context/__tests__/self-context.test.ts
@@ -58,7 +58,7 @@ describe("buildSelfContext", () => {
     expect(result).toContain("Rival");
     expect(result).toContain("CI tool for devs");
     expect(result).toContain("Powered by Tabstack");
-    expect(result!.length).toBeLessThanOrEqual(1200); // 800 payload cap + framing overhead
+    expect(result?.length ?? 0).toBeLessThanOrEqual(1200); // 800 payload cap + framing overhead
   });
 
   it("lets manual_data override brief fields", async () => {

--- a/lib/context/__tests__/self-context.test.ts
+++ b/lib/context/__tests__/self-context.test.ts
@@ -118,5 +118,30 @@ describe("buildSelfContext", () => {
     const { buildSelfContext } = await import("@/lib/context/self-context");
     const result = await buildSelfContext({ isDemo: true });
     expect(result).toBeNull();
+    // Demo path must short-circuit before the DB query; prevents a future
+    // refactor from leaking demo loads through the self lookup.
+    expect(competitorFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("filters non-string array elements out of differentiators and recent_signals", async () => {
+    competitorFindFirstMock.mockResolvedValue({
+      id: "self_1",
+      name: "Rival",
+      isSelf: true,
+      intelligenceBrief: {
+        positioning_summary: "x",
+        icp_summary: "x",
+        pricing_summary: "x",
+        differentiators: ["valid", { object: "noise" }, 42, "", "also valid"],
+        recent_signals: [null, "signal", undefined]
+      },
+      manualData: null
+    });
+    const { buildSelfContext } = await import("@/lib/context/self-context");
+    const result = await buildSelfContext();
+    expect(result).toContain("valid; also valid");
+    expect(result).toContain("signal");
+    expect(result).not.toContain("[object Object]");
+    expect(result).not.toContain("42");
   });
 });

--- a/lib/context/self-context.ts
+++ b/lib/context/self-context.ts
@@ -76,15 +76,26 @@ export async function buildSelfContext(options: BuildSelfContextOptions = {}): P
 
   const parts: string[] = [];
   parts.push(`Name: ${self.name}`);
-  if (fields.positioning_summary) parts.push(`Positioning: ${fields.positioning_summary}`);
-  if (fields.icp_summary) parts.push(`ICP: ${fields.icp_summary}`);
-  if (fields.pricing_summary) parts.push(`Pricing: ${fields.pricing_summary}`);
-  if (fields.differentiators?.length) {
-    parts.push(`What makes us distinct: ${fields.differentiators.join("; ")}`);
+  if (typeof fields.positioning_summary === "string" && fields.positioning_summary) {
+    parts.push(`Positioning: ${fields.positioning_summary}`);
   }
-  if (fields.recent_signals?.length) {
-    parts.push(`Recent signals: ${fields.recent_signals.join("; ")}`);
+  if (typeof fields.icp_summary === "string" && fields.icp_summary) {
+    parts.push(`ICP: ${fields.icp_summary}`);
   }
+  if (typeof fields.pricing_summary === "string" && fields.pricing_summary) {
+    parts.push(`Pricing: ${fields.pricing_summary}`);
+  }
+  // JSON columns have no runtime guarantees for array element types, so
+  // filter for strings before joining. Prevents "[object Object]" leaking
+  // into every downstream prompt if the brief schema ever drifts.
+  const diffs = Array.isArray(fields.differentiators)
+    ? fields.differentiators.filter((d): d is string => typeof d === "string" && d.length > 0)
+    : [];
+  if (diffs.length) parts.push(`What makes us distinct: ${diffs.join("; ")}`);
+  const signals = Array.isArray(fields.recent_signals)
+    ? fields.recent_signals.filter((s): s is string => typeof s === "string" && s.length > 0)
+    : [];
+  if (signals.length) parts.push(`Recent signals: ${signals.join("; ")}`);
   if (Object.keys(extras).length > 0) {
     parts.push(`User notes: ${JSON.stringify(extras)}`);
   }

--- a/lib/context/self-context.ts
+++ b/lib/context/self-context.ts
@@ -1,0 +1,97 @@
+/**
+ * Builds a compact context string describing the user's own company,
+ * for injection into every competitor-facing AI call (brief, research, compare).
+ *
+ * When:
+ * - Returns null if no self row exists, or if the self brief has not yet been
+ *   generated. Callers pass through without injection.
+ * - Returns null when isDemo is true. Demo scans target arbitrary URLs the user
+ *   pastes, which are not the operator's product — injecting self-context
+ *   would poison the output.
+ *
+ * Output shape: a short prose block capped at ~800 chars of payload, with
+ * framing that tells the downstream prompt NOT to echo it back.
+ */
+
+import { prisma } from "@/lib/db/client";
+import { isPlainObject } from "@/lib/utils/types";
+
+const MAX_PAYLOAD_CHARS = 800;
+
+type SelfBriefShape = {
+  positioning_summary?: string;
+  icp_summary?: string;
+  pricing_summary?: string;
+  differentiators?: string[];
+  recent_signals?: string[];
+};
+
+const KNOWN_BRIEF_KEYS = new Set<string>([
+  "positioning_summary",
+  "icp_summary",
+  "pricing_summary",
+  "differentiators",
+  "recent_signals"
+]);
+
+function mergeBriefAndManual(
+  brief: SelfBriefShape,
+  manual: Record<string, unknown> | null
+): { fields: SelfBriefShape; extras: Record<string, unknown> } {
+  if (!manual) return { fields: brief, extras: {} };
+  const merged: SelfBriefShape = { ...brief };
+  const extras: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(manual)) {
+    if (KNOWN_BRIEF_KEYS.has(key)) {
+      (merged as Record<string, unknown>)[key] = value;
+    } else {
+      extras[key] = value;
+    }
+  }
+  return { fields: merged, extras };
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return text.slice(0, limit) + "…";
+}
+
+export type BuildSelfContextOptions = {
+  isDemo?: boolean;
+};
+
+export async function buildSelfContext(options: BuildSelfContextOptions = {}): Promise<string | null> {
+  if (options.isDemo) return null;
+
+  const self = await prisma.competitor.findFirst({
+    where: { isSelf: true }
+  });
+
+  if (!self) return null;
+  if (!self.intelligenceBrief || !isPlainObject(self.intelligenceBrief)) return null;
+
+  const brief = self.intelligenceBrief as SelfBriefShape;
+  const manual = isPlainObject(self.manualData) ? (self.manualData as Record<string, unknown>) : null;
+  const { fields, extras } = mergeBriefAndManual(brief, manual);
+
+  const parts: string[] = [];
+  parts.push(`Name: ${self.name}`);
+  if (fields.positioning_summary) parts.push(`Positioning: ${fields.positioning_summary}`);
+  if (fields.icp_summary) parts.push(`ICP: ${fields.icp_summary}`);
+  if (fields.pricing_summary) parts.push(`Pricing: ${fields.pricing_summary}`);
+  if (fields.differentiators?.length) {
+    parts.push(`What makes us distinct: ${fields.differentiators.join("; ")}`);
+  }
+  if (fields.recent_signals?.length) {
+    parts.push(`Recent signals: ${fields.recent_signals.join("; ")}`);
+  }
+  if (Object.keys(extras).length > 0) {
+    parts.push(`User notes: ${JSON.stringify(extras)}`);
+  }
+
+  const payload = truncate(parts.join("\n"), MAX_PAYLOAD_CHARS);
+
+  return `CONTEXT — about the user's own company (who this brief is for):
+${payload}
+Use this to frame recommendations, threat levels, and opportunities relative to THIS company specifically. Do not echo this context in the output.`;
+}

--- a/lib/db/__tests__/competitors.test.ts
+++ b/lib/db/__tests__/competitors.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { competitorFindManyMock, competitorFindUniqueMock } = vi.hoisted(() => ({
-  competitorFindManyMock: vi.fn(),
-  competitorFindUniqueMock: vi.fn()
+const { findManyMock, findFirstMock, findUniqueMock } = vi.hoisted(() => ({
+  findManyMock: vi.fn(),
+  findFirstMock: vi.fn(),
+  findUniqueMock: vi.fn()
 }));
 
 vi.mock("@/lib/db/client", () => ({
   prisma: {
     competitor: {
-      findMany: competitorFindManyMock,
-      findUnique: competitorFindUniqueMock
+      findMany: findManyMock,
+      findFirst: findFirstMock,
+      findUnique: findUniqueMock
     }
   }
 }));
@@ -18,30 +20,46 @@ const COMPETITOR = { id: "cmp_1", name: "Acme", slug: "acme", pages: [] };
 
 describe("lib/db/competitors", () => {
   beforeEach(() => {
-    competitorFindManyMock.mockReset();
-    competitorFindUniqueMock.mockReset();
-    competitorFindManyMock.mockResolvedValue([COMPETITOR]);
-    competitorFindUniqueMock.mockResolvedValue(COMPETITOR);
+    vi.resetModules();
+    findManyMock.mockReset().mockResolvedValue([COMPETITOR]);
+    findFirstMock.mockReset().mockResolvedValue(null);
+    findUniqueMock.mockReset().mockResolvedValue(COMPETITOR);
   });
 
   describe("listCompetitors", () => {
     it("returns all competitors ordered by name", async () => {
       const { listCompetitors } = await import("@/lib/db/competitors");
       const result = await listCompetitors();
-      expect(competitorFindManyMock).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { name: "asc" } }));
+      expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { name: "asc" } }));
       expect(result).toEqual([COMPETITOR]);
     });
 
     it("does not include pages by default", async () => {
       const { listCompetitors } = await import("@/lib/db/competitors");
       await listCompetitors();
-      expect(competitorFindManyMock).toHaveBeenCalledWith(expect.objectContaining({ include: undefined }));
+      expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({ include: undefined }));
     });
 
     it("includes pages when includePages is true", async () => {
       const { listCompetitors } = await import("@/lib/db/competitors");
       await listCompetitors({ includePages: true });
-      expect(competitorFindManyMock).toHaveBeenCalledWith(expect.objectContaining({ include: { pages: true } }));
+      expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({ include: { pages: true } }));
+    });
+
+    it("excludes self rows by default", async () => {
+      const { listCompetitors } = await import("@/lib/db/competitors");
+      await listCompetitors();
+      expect(findManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { isSelf: false } })
+      );
+    });
+
+    it("includes self rows when includeSelf is true", async () => {
+      const { listCompetitors } = await import("@/lib/db/competitors");
+      await listCompetitors({ includeSelf: true });
+      const call = findManyMock.mock.calls[0][0];
+      // Either `where` is omitted, or `where` does NOT contain `isSelf: false`:
+      expect(call?.where?.isSelf).not.toBe(false);
     });
   });
 
@@ -49,7 +67,7 @@ describe("lib/db/competitors", () => {
     it("fetches a competitor by id including pages", async () => {
       const { getCompetitorById } = await import("@/lib/db/competitors");
       const result = await getCompetitorById("cmp_1");
-      expect(competitorFindUniqueMock).toHaveBeenCalledWith({
+      expect(findUniqueMock).toHaveBeenCalledWith({
         where: { id: "cmp_1" },
         include: { pages: true }
       });
@@ -57,7 +75,7 @@ describe("lib/db/competitors", () => {
     });
 
     it("returns null when competitor is not found", async () => {
-      competitorFindUniqueMock.mockResolvedValueOnce(null);
+      findUniqueMock.mockResolvedValueOnce(null);
       const { getCompetitorById } = await import("@/lib/db/competitors");
       const result = await getCompetitorById("missing");
       expect(result).toBeNull();
@@ -68,7 +86,7 @@ describe("lib/db/competitors", () => {
     it("fetches a competitor by slug including pages", async () => {
       const { getCompetitorBySlug } = await import("@/lib/db/competitors");
       const result = await getCompetitorBySlug("acme");
-      expect(competitorFindUniqueMock).toHaveBeenCalledWith({
+      expect(findUniqueMock).toHaveBeenCalledWith({
         where: { slug: "acme" },
         include: { pages: true }
       });
@@ -76,9 +94,27 @@ describe("lib/db/competitors", () => {
     });
 
     it("returns null when slug is not found", async () => {
-      competitorFindUniqueMock.mockResolvedValueOnce(null);
+      findUniqueMock.mockResolvedValueOnce(null);
       const { getCompetitorBySlug } = await import("@/lib/db/competitors");
       const result = await getCompetitorBySlug("unknown-slug");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getSelfCompetitor", () => {
+    it("queries for the row with isSelf = true including pages", async () => {
+      const { getSelfCompetitor } = await import("@/lib/db/competitors");
+      await getSelfCompetitor();
+      expect(findFirstMock).toHaveBeenCalledWith({
+        where: { isSelf: true },
+        include: { pages: true }
+      });
+    });
+
+    it("returns whatever Prisma returns (including null)", async () => {
+      findFirstMock.mockResolvedValue(null);
+      const { getSelfCompetitor } = await import("@/lib/db/competitors");
+      const result = await getSelfCompetitor();
       expect(result).toBeNull();
     });
   });

--- a/lib/db/__tests__/competitors.test.ts
+++ b/lib/db/__tests__/competitors.test.ts
@@ -57,9 +57,13 @@ describe("lib/db/competitors", () => {
     it("includes self rows when includeSelf is true", async () => {
       const { listCompetitors } = await import("@/lib/db/competitors");
       await listCompetitors({ includeSelf: true });
+      // The where clause must be absent entirely — not merely `{ isSelf: undefined }`,
+      // which would still filter out rows where is_self is actually true.
+      expect(findManyMock).toHaveBeenCalledWith(
+        expect.not.objectContaining({ where: { isSelf: false } })
+      );
       const call = findManyMock.mock.calls[0][0];
-      // Either `where` is omitted, or `where` does NOT contain `isSelf: false`:
-      expect(call?.where?.isSelf).not.toBe(false);
+      expect(call?.where).toBeUndefined();
     });
   });
 

--- a/lib/db/__tests__/competitors.test.ts
+++ b/lib/db/__tests__/competitors.test.ts
@@ -49,9 +49,7 @@ describe("lib/db/competitors", () => {
     it("excludes self rows by default", async () => {
       const { listCompetitors } = await import("@/lib/db/competitors");
       await listCompetitors();
-      expect(findManyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { isSelf: false } })
-      );
+      expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({ where: { isSelf: false } }));
     });
 
     it("includes self rows when includeSelf is true", async () => {
@@ -59,9 +57,7 @@ describe("lib/db/competitors", () => {
       await listCompetitors({ includeSelf: true });
       // The where clause must be absent entirely — not merely `{ isSelf: undefined }`,
       // which would still filter out rows where is_self is actually true.
-      expect(findManyMock).toHaveBeenCalledWith(
-        expect.not.objectContaining({ where: { isSelf: false } })
-      );
+      expect(findManyMock).toHaveBeenCalledWith(expect.not.objectContaining({ where: { isSelf: false } }));
       const call = findManyMock.mock.calls[0][0];
       expect(call?.where).toBeUndefined();
     });

--- a/lib/db/competitors.ts
+++ b/lib/db/competitors.ts
@@ -2,10 +2,12 @@ import { prisma } from "@/lib/db/client";
 
 export type CompetitorListFilters = {
   includePages?: boolean;
+  includeSelf?: boolean;
 };
 
 export async function listCompetitors(filters: CompetitorListFilters = {}) {
   return prisma.competitor.findMany({
+    where: filters.includeSelf ? undefined : { isSelf: false },
     orderBy: { name: "asc" },
     include: filters.includePages ? { pages: true } : undefined
   });
@@ -21,6 +23,13 @@ export async function getCompetitorById(id: string) {
 export async function getCompetitorBySlug(slug: string) {
   return prisma.competitor.findUnique({
     where: { slug },
+    include: { pages: true }
+  });
+}
+
+export async function getSelfCompetitor() {
+  return prisma.competitor.findFirst({
+    where: { isSelf: true },
     include: { pages: true }
   });
 }

--- a/lib/run-scans.ts
+++ b/lib/run-scans.ts
@@ -1,4 +1,4 @@
-import { generateCompetitorBrief } from "./brief";
+import { generateCompetitorBrief, generateSelfBrief } from "./brief";
 import { prisma } from "./db/client";
 import { scanPage } from "./scanner";
 
@@ -7,6 +7,7 @@ const STALE_LOCK_AGE_MS = 60 * 60 * 1000; // 1 hour
 
 type CompetitorWithPages = {
   id: string;
+  isSelf: boolean;
   pages: Array<{
     id: string;
     label: string;
@@ -48,7 +49,11 @@ async function processCompetitor(competitor: CompetitorWithPages, briefNocache: 
   }
 
   try {
-    await generateCompetitorBrief(competitor.id, briefNocache);
+    if (competitor.isSelf) {
+      await generateSelfBrief(competitor.id, briefNocache);
+    } else {
+      await generateCompetitorBrief(competitor.id, briefNocache);
+    }
     item.briefGenerated = true;
   } catch (error) {
     item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -456,4 +456,22 @@ describe("generateSelfProfile", () => {
     // Assert it does NOT contain the competitor-brief distinguishing phrase
     expect(sdkCall.instructions).not.toContain("competitive intelligence analyst");
   });
+
+  it("passes competitorId and expectedFields to logger metadata", async () => {
+    const { generateSelfProfile, SELF_PROFILE_EXPECTED_FIELDS } = await import("@/lib/tabstack/generate");
+    generateJsonMock.mockResolvedValue({});
+
+    await generateSelfProfile({
+      competitorId: "self_1",
+      url: "https://rival.so",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    const [, metadata] = loggerCallMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(metadata.competitorId).toBe("self_1");
+    expect(metadata.endpoint).toBe("generate");
+    expect(metadata.expectedFields).toEqual(SELF_PROFILE_EXPECTED_FIELDS);
+  });
 });

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -426,7 +426,10 @@ describe("generateBrief with self-context injection", () => {
     expect(instructions).toContain("competitive intelligence analyst");
   });
 
-  it("passes isDemo through to buildSelfContext", async () => {
+  it("does not inject self-context when isDemo is true", async () => {
+    buildSelfContextMock.mockImplementation(async (opts: { isDemo?: boolean } = {}) =>
+      opts.isDemo ? null : "CONTEXT — about the user's own company...\nName: Rival"
+    );
     generateJsonMock.mockResolvedValue({});
     const { generateBrief } = await import("@/lib/tabstack/generate");
 
@@ -439,6 +442,9 @@ describe("generateBrief with self-context injection", () => {
       isDemo: true
     });
 
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    const instructions = sdkCall.instructions as string;
+    expect(instructions).not.toContain("CONTEXT — about the user's own company");
     expect(buildSelfContextMock).toHaveBeenCalledWith(expect.objectContaining({ isDemo: true }));
   });
 });

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -2,15 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // All mock functions defined in vi.hoisted so they are initialized before
 // vi.mock() factories run (vi.mock calls are hoisted above const declarations).
-const { generateJsonMock, loggerCallMock, getTabstackClientMock, toSdkEffortMock, toGeoTargetMock } = vi.hoisted(
-  () => ({
-    generateJsonMock: vi.fn(),
-    loggerCallMock: vi.fn(async (fn: () => Promise<unknown>, _meta?: unknown) => fn()),
-    getTabstackClientMock: vi.fn(),
-    toSdkEffortMock: vi.fn(),
-    toGeoTargetMock: vi.fn()
-  })
-);
+const {
+  generateJsonMock,
+  loggerCallMock,
+  getTabstackClientMock,
+  toSdkEffortMock,
+  toGeoTargetMock,
+  buildSelfContextMock
+} = vi.hoisted(() => ({
+  generateJsonMock: vi.fn(),
+  loggerCallMock: vi.fn(async (fn: () => Promise<unknown>, _meta?: unknown) => fn()),
+  getTabstackClientMock: vi.fn(),
+  toSdkEffortMock: vi.fn(),
+  toGeoTargetMock: vi.fn(),
+  buildSelfContextMock: vi.fn().mockResolvedValue(null)
+}));
 
 // Mock at the tabstack client wrapper boundary — not the raw @tabstack/sdk.
 // Real toSdkEffort and toGeoTarget behaviour is validated via the mocks below,
@@ -26,6 +32,10 @@ vi.mock("@/lib/tabstack/client", () => ({
 // result, so both SDK params and logger metadata can be asserted.
 vi.mock("@/lib/logger", () => ({
   logger: { call: loggerCallMock }
+}));
+
+vi.mock("@/lib/context/self-context", () => ({
+  buildSelfContext: buildSelfContextMock
 }));
 
 describe("generateDiff", () => {
@@ -356,6 +366,80 @@ describe("generateBrief", () => {
       expect.objectContaining({ code: "RIVAL_CONTEXT_TRUNCATED" })
     );
     warnSpy.mockRestore();
+  });
+});
+
+describe("generateBrief with self-context injection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loggerCallMock.mockClear();
+    generateJsonMock.mockClear();
+    process.env.TABSTACK_API_KEY = "test-key";
+    loggerCallMock.mockImplementation((fn: () => Promise<unknown>) => fn());
+    toSdkEffortMock.mockImplementation((effort: string) => (effort === "high" ? "max" : "standard"));
+    toGeoTargetMock.mockImplementation((code?: string | null) => {
+      if (!code) return undefined;
+      const n = code.trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(n) ? { country: n } : undefined;
+    });
+    getTabstackClientMock.mockReturnValue({ generate: { json: generateJsonMock } });
+    buildSelfContextMock.mockReset().mockResolvedValue(null);
+  });
+
+  it("prepends self-context to instructions when buildSelfContext returns a string", async () => {
+    buildSelfContextMock.mockResolvedValue("CONTEXT — about the user's own company...\nName: Rival");
+    generateJsonMock.mockResolvedValue({});
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: JSON.stringify([{ page_type: "homepage", result: {} }]),
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    const instructions = sdkCall.instructions as string;
+    expect(instructions).toContain("CONTEXT — about the user's own company");
+    expect(instructions).toContain("Additional competitor context:");
+    // Self-context should precede the analyst persona:
+    expect(instructions.indexOf("CONTEXT")).toBeLessThan(instructions.indexOf("competitive intelligence analyst"));
+  });
+
+  it("does NOT prepend self-context when buildSelfContext returns null", async () => {
+    buildSelfContextMock.mockResolvedValue(null);
+    generateJsonMock.mockResolvedValue({});
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    const instructions = sdkCall.instructions as string;
+    expect(instructions).not.toContain("CONTEXT — about the user's own company");
+    expect(instructions).toContain("competitive intelligence analyst");
+  });
+
+  it("passes isDemo through to buildSelfContext", async () => {
+    generateJsonMock.mockResolvedValue({});
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: null,
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true,
+      isDemo: true
+    });
+
+    expect(buildSelfContextMock).toHaveBeenCalledWith(expect.objectContaining({ isDemo: true }));
   });
 });
 

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -381,3 +381,79 @@ describe("schema exports", () => {
     expect(BRIEF_SCHEMA.required).toContain("positioning_opportunity");
   });
 });
+
+describe("generateSelfProfile", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loggerCallMock.mockClear();
+    generateJsonMock.mockClear();
+    process.env.TABSTACK_API_KEY = "test-key";
+    loggerCallMock.mockImplementation((fn: () => Promise<unknown>) => fn());
+    toSdkEffortMock.mockImplementation((effort: string) => (effort === "high" ? "max" : "standard"));
+    toGeoTargetMock.mockImplementation((code?: string | null) => {
+      if (!code) return undefined;
+      const n = code.trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(n) ? { country: n } : undefined;
+    });
+    getTabstackClientMock.mockReturnValue({ generate: { json: generateJsonMock } });
+  });
+
+  it("calls tabstack /generate with SELF_PROFILE_SCHEMA and the provided context", async () => {
+    const { generateSelfProfile, SELF_PROFILE_EXPECTED_FIELDS } = await import("@/lib/tabstack/generate");
+    const mockProfile = {
+      positioning_summary: "CI tool for devs",
+      icp_summary: "Developer teams",
+      pricing_summary: "Open source",
+      differentiators: ["Fast", "Simple"],
+      recent_signals: ["New release"]
+    };
+    generateJsonMock.mockResolvedValue(mockProfile);
+
+    const contextData = JSON.stringify([{ page_type: "homepage", result: { headline: "CI for devs" } }]);
+    const response = await generateSelfProfile({
+      competitorId: "self_1",
+      url: "https://rival.so",
+      contextData,
+      effort: "low",
+      nocache: true
+    });
+
+    expect(response).toBeDefined();
+    expect(SELF_PROFILE_EXPECTED_FIELDS).toEqual(
+      expect.arrayContaining([
+        "positioning_summary",
+        "icp_summary",
+        "pricing_summary",
+        "differentiators",
+        "recent_signals"
+      ])
+    );
+
+    // Assert the mocked tabstack client was called with json_schema === SELF_PROFILE_SCHEMA
+    const { SELF_PROFILE_SCHEMA } = await import("@/lib/tabstack/generate");
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    expect(sdkCall.json_schema).toEqual(SELF_PROFILE_SCHEMA);
+
+    // Assert instructions contain the contextData substring
+    expect(sdkCall.instructions).toContain(contextData);
+  });
+
+  it("uses the self-profile instruction prompt (not the competitor-brief prompt)", async () => {
+    const { generateSelfProfile } = await import("@/lib/tabstack/generate");
+    generateJsonMock.mockResolvedValue({});
+
+    await generateSelfProfile({
+      competitorId: "self_1",
+      url: "https://rival.so",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    // Assert the call's instructions contains "self-profile" distinguishing phrase
+    expect(sdkCall.instructions).toContain("self-profile");
+    // Assert it does NOT contain the competitor-brief distinguishing phrase
+    expect(sdkCall.instructions).not.toContain("competitive intelligence analyst");
+  });
+});

--- a/lib/tabstack/__tests__/research.test.ts
+++ b/lib/tabstack/__tests__/research.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResearchEvent } from "@tabstack/sdk/resources/agent";
 
-const { researchMock, loggerCallMock, getTabstackClientMock } = vi.hoisted(() => ({
+const { researchMock, loggerCallMock, getTabstackClientMock, buildSelfContextMock } = vi.hoisted(() => ({
   researchMock: vi.fn(),
   loggerCallMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  getTabstackClientMock: vi.fn()
+  getTabstackClientMock: vi.fn(),
+  buildSelfContextMock: vi.fn().mockResolvedValue(null)
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -13,6 +14,10 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/lib/tabstack/client", () => ({
   getTabstackClient: getTabstackClientMock
+}));
+
+vi.mock("@/lib/context/self-context", () => ({
+  buildSelfContext: buildSelfContextMock
 }));
 
 function makeStream(events: ResearchEvent[]): AsyncIterable<ResearchEvent> {
@@ -38,6 +43,7 @@ describe("runResearch", () => {
     researchMock.mockReset();
     getTabstackClientMock.mockReset();
     getTabstackClientMock.mockReturnValue({ agent: { research: researchMock } });
+    buildSelfContextMock.mockReset().mockResolvedValue(null);
     process.env.TABSTACK_API_KEY = "test-key";
   });
 
@@ -285,5 +291,71 @@ describe("runResearch", () => {
     researchMock.mockRejectedValue(new Error("Network failure"));
 
     await expect(runResearch({ query: "q", mode: "fast" })).rejects.toThrow("Network failure");
+  });
+});
+
+describe("runResearch with self-context injection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loggerCallMock.mockReset();
+    loggerCallMock.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    researchMock.mockReset();
+    getTabstackClientMock.mockReset();
+    getTabstackClientMock.mockReturnValue({ agent: { research: researchMock } });
+    buildSelfContextMock.mockReset().mockResolvedValue(null);
+    process.env.TABSTACK_API_KEY = "test-key";
+  });
+
+  it("prepends self-context to the query when buildSelfContext returns a string", async () => {
+    buildSelfContextMock.mockResolvedValue("CONTEXT — about the user's own company...\nName: Rival");
+    researchMock.mockResolvedValue(makeStream([{ event: "complete", data: { result: "r", citations: [] } }]));
+
+    const { runResearch } = await import("@/lib/tabstack/research");
+    await runResearch({
+      competitorId: "cmp_1",
+      query: "What are customers saying about Acme?",
+      mode: "fast"
+    });
+
+    const researchCall = researchMock.mock.calls[0][0] as { query: string };
+    const query = researchCall.query;
+    expect(query).toContain("CONTEXT — about the user's own company");
+    expect(query).toContain("What are customers saying about Acme?");
+    // Self-context should come first:
+    expect(query.indexOf("CONTEXT")).toBeLessThan(query.indexOf("What are customers saying"));
+  });
+
+  it("leaves the research query untouched when buildSelfContext returns null", async () => {
+    buildSelfContextMock.mockResolvedValue(null);
+    researchMock.mockResolvedValue(makeStream([{ event: "complete", data: { result: "r", citations: [] } }]));
+
+    const { runResearch } = await import("@/lib/tabstack/research");
+    await runResearch({
+      competitorId: "cmp_1",
+      query: "What are customers saying?",
+      mode: "fast"
+    });
+
+    const researchCall = researchMock.mock.calls[0][0] as { query: string };
+    expect(researchCall.query).toBe("What are customers saying?");
+  });
+
+  it("does not inject self-context for demo research calls", async () => {
+    buildSelfContextMock.mockImplementation(async (opts: { isDemo?: boolean } = {}) =>
+      opts.isDemo ? null : "CONTEXT — about the user's own company..."
+    );
+    researchMock.mockResolvedValue(makeStream([{ event: "complete", data: { result: "r", citations: [] } }]));
+
+    const { runResearch } = await import("@/lib/tabstack/research");
+    await runResearch({
+      competitorId: null,
+      query: "Anything",
+      mode: "fast",
+      isDemo: true
+    });
+
+    const researchCall = researchMock.mock.calls[0][0] as { query: string };
+    expect(researchCall.query).not.toContain("CONTEXT — about the user's own company");
+    expect(buildSelfContextMock).toHaveBeenCalledWith(expect.objectContaining({ isDemo: true }));
   });
 });

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -250,6 +250,9 @@ export async function generateBrief(input: GenerateBriefInput): Promise<Generate
 
   const selfContext = await buildSelfContext({ isDemo: input.isDemo });
 
+  // selfContext is bounded by buildSelfContext's internal payload cap
+  // (~800 chars). Combined with the contextData slice above, total
+  // instructions length stays well under Tabstack's /generate limits.
   const instructions = `${selfContext ? `${selfContext}\n\n` : ""}You are a competitive intelligence analyst. Based on this competitor data,
 produce a structured brief covering:
 1. Positioning opportunity — what gap does their weakness create?

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -308,3 +308,101 @@ ${contextData}`;
     expectedFields: BRIEF_EXPECTED_FIELDS
   });
 }
+
+// ---------------------------------------------------------------------------
+// Self-profile
+// ---------------------------------------------------------------------------
+
+/**
+ * Output schema for self-profile generation.
+ * Covers positioning, ICP, pricing, differentiators, and recent signals.
+ */
+export const SELF_PROFILE_SCHEMA = {
+  type: "object",
+  properties: {
+    positioning_summary: {
+      type: "string",
+      description: "1–2 sentences describing who this company is and what it sells."
+    },
+    icp_summary: {
+      type: "string",
+      description: "1–2 sentences describing the company's ideal customer profile."
+    },
+    pricing_summary: {
+      type: "string",
+      description: "Brief description of the monetization model (free, paid, freemium, OSS+paid, etc.)."
+    },
+    differentiators: {
+      type: "array",
+      items: { type: "string" },
+      description: "3–5 bullets naming what makes this company distinct."
+    },
+    recent_signals: {
+      type: "array",
+      items: { type: "string" },
+      description: "3–5 bullets of recent changes visible from changelog, blog, or careers."
+    }
+  },
+  required: ["positioning_summary", "icp_summary", "pricing_summary", "differentiators", "recent_signals"]
+} as const;
+
+export const SELF_PROFILE_EXPECTED_FIELDS: string[] = [...SELF_PROFILE_SCHEMA.required];
+
+export type GenerateSelfProfileInput = GenerateBriefInput;
+
+/**
+ * Analyze the user's own company data and produce a structured self-profile.
+ * This output is stored on the self Competitor row and later injected as context
+ * into every competitor-facing AI call (brief, research, compare).
+ */
+export async function generateSelfProfile(input: GenerateSelfProfileInput): Promise<GenerateJsonResponse> {
+  const client = getTabstackClient();
+  const geoTarget = toGeoTarget(input.geoTarget);
+  const contextData = input.contextData.slice(0, MAX_CONTEXT_LENGTH);
+  if (input.contextData.length > MAX_CONTEXT_LENGTH) {
+    process.emitWarning(
+      `[generateSelfProfile] contextData truncated from ${input.contextData.length} to ${MAX_CONTEXT_LENGTH} chars`,
+      { code: "RIVAL_CONTEXT_TRUNCATED" }
+    );
+  }
+
+  const instructions = `You are analyzing a company's own public surfaces (website, pricing,
+docs, changelog, careers, blog, social) to produce a concise self-profile. This
+profile will later be used as context when evaluating competitors, so it must be
+factual and compact.
+
+Produce:
+1. positioning_summary — 1–2 sentences: who they are, what they sell.
+2. icp_summary — 1–2 sentences: who they serve (technical ICP + use case).
+3. pricing_summary — monetization model in one short paragraph.
+4. differentiators — 3–5 bullets of what makes them distinct (not marketing fluff).
+5. recent_signals — 3–5 bullets of recent changes visible in changelog, blog, or careers.
+
+Be direct and specific. No generic commentary. Do not speculate — only describe
+what the data shows.
+
+Company data:
+${contextData}`;
+
+  const requestPayload: GenerateJsonParams = {
+    url: input.url,
+    instructions,
+    json_schema: SELF_PROFILE_SCHEMA,
+    effort: toSdkEffort(input.effort),
+    nocache: input.nocache,
+    geo_target: geoTarget
+  };
+
+  return logger.call(() => client.generate.json(requestPayload), {
+    competitorId: input.competitorId,
+    pageId: input.pageId,
+    endpoint: "generate",
+    url: input.url,
+    effort: input.effort,
+    nocache: input.nocache,
+    geoTarget: geoTarget?.country,
+    isDemo: input.isDemo,
+    fallback: input.fallback,
+    expectedFields: SELF_PROFILE_EXPECTED_FIELDS
+  });
+}

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -14,6 +14,7 @@
  * When to use vs alternatives:
  * - Use generateDiff after each scan cycle to summarize what changed.
  * - Use generateBrief after a full scan cycle to produce competitive positioning.
+ * - Use generateSelfProfile to analyze the user's own company surfaces and produce a self-profile used as context when evaluating competitors. Do not call on the demo path.
  * - Use /extract/json when you need raw structured data without LLM transformation.
  * - Use /research when you need open-web research beyond a single URL.
  *
@@ -348,7 +349,7 @@ export const SELF_PROFILE_SCHEMA = {
 
 export const SELF_PROFILE_EXPECTED_FIELDS: string[] = [...SELF_PROFILE_SCHEMA.required];
 
-export type GenerateSelfProfileInput = GenerateBriefInput;
+export type GenerateSelfProfileInput = Omit<GenerateBriefInput, "fallback" | "isDemo">;
 
 /**
  * Analyze the user's own company data and produce a structured self-profile.
@@ -401,8 +402,6 @@ ${contextData}`;
     effort: input.effort,
     nocache: input.nocache,
     geoTarget: geoTarget?.country,
-    isDemo: input.isDemo,
-    fallback: input.fallback,
     expectedFields: SELF_PROFILE_EXPECTED_FIELDS
   });
 }

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -35,6 +35,7 @@ import type { GenerateJsonParams, GenerateJsonResponse } from "@tabstack/sdk/res
 
 import { logger, type LoggerCallMetadata, type TabstackEffort } from "@/lib/logger";
 import { getTabstackClient, toGeoTarget, toSdkEffort } from "@/lib/tabstack/client";
+import { buildSelfContext } from "@/lib/context/self-context";
 
 const MAX_CONTEXT_LENGTH = 50_000;
 
@@ -247,7 +248,9 @@ export async function generateBrief(input: GenerateBriefInput): Promise<Generate
     );
   }
 
-  const instructions = `You are a competitive intelligence analyst. Based on this competitor data,
+  const selfContext = await buildSelfContext({ isDemo: input.isDemo });
+
+  const instructions = `${selfContext ? `${selfContext}\n\n` : ""}You are a competitive intelligence analyst. Based on this competitor data,
 produce a structured brief covering:
 1. Positioning opportunity — what gap does their weakness create?
 2. Content opportunity — what topics should you own based on their blind spots?

--- a/lib/tabstack/research.ts
+++ b/lib/tabstack/research.ts
@@ -183,7 +183,15 @@ export async function runResearch(input: ResearchInput): Promise<ResearchResult>
 
   return logger.call(
     async () => {
+      // NOTE: buildSelfContext runs inside logger.call's timed body, so
+      // durationMs in api_logs includes a ~10–50ms Prisma round-trip on top
+      // of the Tabstack SDK call. Negligible in balanced mode; small but
+      // measurable fraction in fast mode. Matches the pattern in generate.ts.
       const selfContext = await buildSelfContext({ isDemo: input.isDemo });
+      // "RESEARCH QUESTION:" separates the injected self-context from the
+      // natural-language query. The context block itself ends with a "Do
+      // not echo" directive (see buildSelfContext), which governs output
+      // behavior for both brief and research paths.
       const query = selfContext
         ? `${selfContext}\n\nRESEARCH QUESTION:\n${input.query}`
         : input.query;

--- a/lib/tabstack/research.ts
+++ b/lib/tabstack/research.ts
@@ -192,9 +192,7 @@ export async function runResearch(input: ResearchInput): Promise<ResearchResult>
       // natural-language query. The context block itself ends with a "Do
       // not echo" directive (see buildSelfContext), which governs output
       // behavior for both brief and research paths.
-      const query = selfContext
-        ? `${selfContext}\n\nRESEARCH QUESTION:\n${input.query}`
-        : input.query;
+      const query = selfContext ? `${selfContext}\n\nRESEARCH QUESTION:\n${input.query}` : input.query;
 
       const stream = await client.agent.research({
         query,

--- a/lib/tabstack/research.ts
+++ b/lib/tabstack/research.ts
@@ -46,6 +46,7 @@
 import type { ResearchEvent } from "@tabstack/sdk/resources/agent";
 
 import { logger, type LoggerCallMetadata, type TabstackMode } from "@/lib/logger";
+import { buildSelfContext } from "@/lib/context/self-context";
 import { getTabstackClient } from "@/lib/tabstack/client";
 import { isPlainObject, stringifyUnknown } from "@/lib/utils/types";
 
@@ -182,8 +183,13 @@ export async function runResearch(input: ResearchInput): Promise<ResearchResult>
 
   return logger.call(
     async () => {
+      const selfContext = await buildSelfContext({ isDemo: input.isDemo });
+      const query = selfContext
+        ? `${selfContext}\n\nRESEARCH QUESTION:\n${input.query}`
+        : input.query;
+
       const stream = await client.agent.research({
-        query: input.query,
+        query,
         mode: input.mode,
         nocache: input.nocache
       });

--- a/prisma/migrations/20260421145357_add_is_self_to_competitors/migration.sql
+++ b/prisma/migrations/20260421145357_add_is_self_to_competitors/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "competitors" ADD COLUMN     "is_self" BOOLEAN NOT NULL DEFAULT false;
+
+-- Enforce at most one Competitor row with is_self = true
+CREATE UNIQUE INDEX "competitors_is_self_unique"
+  ON "competitors" ("is_self") WHERE "is_self" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,10 @@ model Competitor {
   intelligenceBrief Json?     @map("intelligence_brief")
   briefGeneratedAt  DateTime? @map("brief_generated_at") @db.Timestamptz(6)
   createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  // Partial unique index on is_self = true is enforced in the migration
+  // (competitors_is_self_unique) and cannot be expressed in Prisma DSL.
+  // Do not regenerate this migration from the schema alone — the partial
+  // index will be lost.
   isSelf            Boolean   @default(false) @map("is_self")
 
   pages         CompetitorPage[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Competitor {
   intelligenceBrief Json?     @map("intelligence_brief")
   briefGeneratedAt  DateTime? @map("brief_generated_at") @db.Timestamptz(6)
   createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  isSelf            Boolean   @default(false) @map("is_self")
 
   pages         CompetitorPage[]
   deepDives     DeepDive[]

--- a/rivals.config.json
+++ b/rivals.config.json
@@ -3,9 +3,7 @@
     "name": "Tabstack",
     "slug": "tabstack",
     "url": "https://tabstack.ai",
-    "pages": [
-      { "label": "Homepage", "url": "https://tabstack.ai", "type": "homepage" }
-    ]
+    "pages": [{ "label": "Homepage", "url": "https://tabstack.ai", "type": "homepage" }]
   },
   "competitors": [
     {

--- a/rivals.config.json
+++ b/rivals.config.json
@@ -1,4 +1,12 @@
 {
+  "self": {
+    "name": "Tabstack",
+    "slug": "tabstack",
+    "url": "https://tabstack.ai",
+    "pages": [
+      { "label": "Homepage", "url": "https://tabstack.ai", "type": "homepage" }
+    ]
+  },
   "competitors": [
     {
       "name": "Firecrawl",

--- a/scripts/bootstrap-new-competitors.ts
+++ b/scripts/bootstrap-new-competitors.ts
@@ -27,7 +27,7 @@
  * Runs automatically as part of the Netlify production build, after seed.
  */
 
-import { generateCompetitorBrief } from "@/lib/brief";
+import { generateCompetitorBrief, generateSelfBrief } from "@/lib/brief";
 import { prisma } from "@/lib/db/client";
 import { scanPage } from "@/lib/scanner";
 
@@ -35,6 +35,7 @@ async function bootstrapCompetitor(competitor: {
   id: string;
   slug: string;
   name: string;
+  isSelf: boolean;
   pages: Array<{ id: string; label: string; url: string; type: string; geoTarget: string | null }>;
 }) {
   console.log(`\n[bootstrap] ${competitor.slug}: scanning ${competitor.pages.length} page(s)...`);
@@ -69,9 +70,13 @@ async function bootstrapCompetitor(competitor: {
 
   console.log(`[bootstrap] ${competitor.slug}: generating brief...`);
   try {
-    const payload = await generateCompetitorBrief(competitor.id, true);
-    const threat = (payload as { threat_level?: string })?.threat_level ?? "—";
-    console.log(`[bootstrap] ${competitor.slug}: brief generated (threat=${threat}, scan errors=${scanErrors}).`);
+    const payload = competitor.isSelf
+      ? await generateSelfBrief(competitor.id, true)
+      : await generateCompetitorBrief(competitor.id, true);
+    const threat = competitor.isSelf ? "—" : ((payload as { threat_level?: string })?.threat_level ?? "—");
+    console.log(
+      `[bootstrap] ${competitor.slug}: brief generated (${competitor.isSelf ? "self-profile" : `threat=${threat}`}, scan errors=${scanErrors}).`
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[bootstrap] ${competitor.slug}: brief failed: ${message}`);

--- a/scripts/refresh-briefs.ts
+++ b/scripts/refresh-briefs.ts
@@ -18,7 +18,7 @@
  *     bounded cost — don't loop this script.
  */
 
-import { generateCompetitorBrief } from "@/lib/brief";
+import { generateCompetitorBrief, generateSelfBrief } from "@/lib/brief";
 import { prisma } from "@/lib/db/client";
 
 type BriefOutcome =
@@ -31,7 +31,7 @@ function formatRow(slug: string, before: string, after: string, detail: string):
 
 async function main() {
   const competitors = await prisma.competitor.findMany({
-    select: { id: true, slug: true, name: true, threatLevel: true },
+    select: { id: true, slug: true, name: true, threatLevel: true, isSelf: true },
     orderBy: { slug: "asc" }
   });
 
@@ -49,7 +49,9 @@ async function main() {
   for (const competitor of competitors) {
     const before = competitor.threatLevel ?? "—";
     try {
-      const payload = await generateCompetitorBrief(competitor.id, true);
+      const payload = competitor.isSelf
+        ? await generateSelfBrief(competitor.id, true)
+        : await generateCompetitorBrief(competitor.id, true);
       const threatRaw = (payload as { threat_level?: unknown })?.threat_level;
       const reasoningRaw = (payload as { threat_reasoning?: unknown })?.threat_reasoning;
       const after = typeof threatRaw === "string" ? threatRaw : "—";

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/client";
-import { parseRivalConfig, type RivalConfigEntry } from "@/lib/config/rival-config";
+import { parseRivalConfig, type ParsedRivalConfig, type RivalConfigEntry } from "@/lib/config/rival-config";
 
-async function loadConfig() {
+async function loadConfig(): Promise<ParsedRivalConfig> {
   const configPath = path.join(process.cwd(), "rivals.config.json");
   const raw = await fs.readFile(configPath, "utf8");
   return parseRivalConfig(JSON.parse(raw));

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -3,26 +3,12 @@ import path from "node:path";
 
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/client";
+import { parseRivalConfig, type RivalConfigEntry } from "@/lib/config/rival-config";
 
-type RivalConfig = {
-  competitors?: Array<{
-    name: string;
-    slug: string;
-    url: string;
-    manual?: Record<string, unknown> & { manual_last_updated?: string };
-    pages?: Array<{
-      label: string;
-      url: string;
-      type: string;
-      geo_target?: string;
-    }>;
-  }>;
-};
-
-async function loadConfig(): Promise<RivalConfig> {
+async function loadConfig() {
   const configPath = path.join(process.cwd(), "rivals.config.json");
   const raw = await fs.readFile(configPath, "utf8");
-  return JSON.parse(raw) as RivalConfig;
+  return parseRivalConfig(JSON.parse(raw));
 }
 
 function toDate(value?: string): Date | null {
@@ -40,62 +26,70 @@ function toJsonValue(value: unknown): Prisma.InputJsonValue | Prisma.NullableJso
   return String(value);
 }
 
+async function upsertEntry(entry: RivalConfigEntry, isSelf: boolean) {
+  const record = await prisma.competitor.upsert({
+    where: { slug: entry.slug },
+    create: {
+      name: entry.name,
+      slug: entry.slug,
+      baseUrl: entry.url,
+      isSelf,
+      manualData: toJsonValue(entry.manual),
+      manualLastUpdated: toDate(entry.manual?.manual_last_updated)
+    },
+    update: {
+      name: entry.name,
+      baseUrl: entry.url,
+      isSelf,
+      manualData: toJsonValue(entry.manual),
+      manualLastUpdated: toDate(entry.manual?.manual_last_updated)
+    }
+  });
+
+  const configUrls = new Set((entry.pages ?? []).map((p) => p.url));
+
+  for (const page of entry.pages ?? []) {
+    const existing = await prisma.competitorPage.findFirst({
+      where: { competitorId: record.id, url: page.url }
+    });
+
+    if (existing) {
+      await prisma.competitorPage.update({
+        where: { id: existing.id },
+        data: { label: page.label, type: page.type, geoTarget: page.geo_target ?? null }
+      });
+    } else {
+      await prisma.competitorPage.create({
+        data: {
+          competitorId: record.id,
+          label: page.label,
+          url: page.url,
+          type: page.type,
+          geoTarget: page.geo_target ?? null
+        }
+      });
+    }
+  }
+
+  return { record, configUrls };
+}
+
 async function main() {
   const prunePages = process.argv.includes("--prune-pages");
   const config = await loadConfig();
-  const competitors = config.competitors ?? [];
+  const entries: Array<{ entry: RivalConfigEntry; isSelf: boolean }> = [];
+  if (config.self) entries.push({ entry: config.self, isSelf: true });
+  for (const c of config.competitors) entries.push({ entry: c, isSelf: false });
 
-  if (competitors.length === 0) {
-    console.log("No competitors in rivals.config.json, nothing to seed.");
+  if (entries.length === 0) {
+    console.log("No self or competitors in rivals.config.json, nothing to seed.");
     return;
   }
 
-  for (const competitor of competitors) {
-    const record = await prisma.competitor.upsert({
-      where: { slug: competitor.slug },
-      create: {
-        name: competitor.name,
-        slug: competitor.slug,
-        baseUrl: competitor.url,
-        manualData: toJsonValue(competitor.manual),
-        manualLastUpdated: toDate(competitor.manual?.manual_last_updated)
-      },
-      update: {
-        name: competitor.name,
-        baseUrl: competitor.url,
-        manualData: toJsonValue(competitor.manual),
-        manualLastUpdated: toDate(competitor.manual?.manual_last_updated)
-      }
-    });
+  for (const { entry, isSelf } of entries) {
+    const { record, configUrls } = await upsertEntry(entry, isSelf);
 
-    const configUrls = new Set((competitor.pages ?? []).map((p) => p.url));
-
-    for (const page of competitor.pages ?? []) {
-      const existing = await prisma.competitorPage.findFirst({
-        where: { competitorId: record.id, url: page.url }
-      });
-
-      if (existing) {
-        await prisma.competitorPage.update({
-          where: { id: existing.id },
-          data: { label: page.label, type: page.type, geoTarget: page.geo_target ?? null }
-        });
-      } else {
-        await prisma.competitorPage.create({
-          data: {
-            competitorId: record.id,
-            label: page.label,
-            url: page.url,
-            type: page.type,
-            geoTarget: page.geo_target ?? null
-          }
-        });
-      }
-    }
-
-    const dbPages = await prisma.competitorPage.findMany({
-      where: { competitorId: record.id }
-    });
+    const dbPages = await prisma.competitorPage.findMany({ where: { competitorId: record.id } });
     const orphaned = dbPages.filter((p) => !configUrls.has(p.url));
 
     if (orphaned.length > 0) {
@@ -113,7 +107,7 @@ async function main() {
       }
     }
 
-    console.log(`Seeded ${record.name} (${record.slug})`);
+    console.log(`Seeded ${isSelf ? "[self] " : ""}${record.name} (${record.slug})`);
   }
 }
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -86,6 +86,23 @@ async function main() {
     return;
   }
 
+  // Demote any previously-flagged self rows whose slug no longer matches the
+  // current config's self. The partial unique index on is_self=true means the
+  // subsequent upsert would otherwise fail when rotating the self slug or
+  // removing the self block entirely. Safe to run even when no prior self
+  // exists — updateMany returns count: 0.
+  const newSelfSlug = config.self?.slug ?? null;
+  const demoted = await prisma.competitor.updateMany({
+    where: {
+      isSelf: true,
+      ...(newSelfSlug ? { slug: { not: newSelfSlug } } : {})
+    },
+    data: { isSelf: false }
+  });
+  if (demoted.count > 0) {
+    console.log(`Demoted ${demoted.count} previously-self competitor row(s) whose slug no longer matches config.self.`);
+  }
+
   for (const { entry, isSelf } of entries) {
     const { record, configUrls } = await upsertEntry(entry, isSelf);
 


### PR DESCRIPTION
## Summary

Gives Rival context about the user's own company (in this demo: Tabstack itself) so every AI-generated surface — competitor brief, threat scoring, deep-dive research, future compare — produces recommendations relative to the user instead of generic commentary.

Self is treated as a `Competitor` row flagged `is_self=true`, going through the existing scanner/cron/brief pipeline unchanged. A new purpose-built self-profile brief (positioning/ICP/pricing/differentiators/recent signals) is injected as context into every competitor-facing AI call.

- Spec: `docs/superpowers/specs/2026-04-21-self-profile-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-self-profile.md`

## What changed

**Data model**
- `Competitor.is_self` boolean + partial unique index (at most one self row)

**Config + seed**
- Optional top-level `self` block in `rivals.config.json` (same shape as a competitor entry)
- New `lib/config/rival-config.ts` pure parser; `scripts/seed.ts` upserts self with `isSelf=true`
- Committed `self` block points at `https://tabstack.ai` (1 page to start; expandable as URLs are verified)

**Self brief (new pipeline surface)**
- `SELF_PROFILE_SCHEMA` + `generateSelfProfile` in `lib/tabstack/generate.ts`
- `generateSelfBrief` in `lib/brief.ts` (asymmetric `isSelf` guards at both entry points prevent cross-row corruption)
- `run-scans.ts`, `scripts/bootstrap-new-competitors.ts`, and `scripts/refresh-briefs.ts` all branch on `isSelf`

**Context injection**
- `lib/context/self-context.ts` builds a compact, capped (~800 char) context string from the self row's brief + manualData override
- Injected into `generateBrief` (prepended to instructions) and `runResearch` (prepended to query)
- `isDemo: true` short-circuits injection before any DB query — demo scans never get self-context

**UI**
- `listCompetitors` excludes self by default; `getSelfCompetitor` helper; dashboard + insights page filter self from the grid
- New `/api/self` read route
- `components/dashboard/SelfProfileCard` + `components/brief/SelfBriefView` render the self row
- Detail page (`app/[slug]/page.tsx`) branches the brief section: self rows render `SelfBriefView` and hide the threat badge

**DX notes** (`notes-local/tabstack-dx-notes.md`, gitignored) — three new entries covering SELF_PROFILE_SCHEMA ergonomics, context injection in `generateBrief`, and context injection in `runResearch` with upstream improvement ideas.

## Rollout safety

Each piece is additive and reversible. Deploying without a `self` block in production config is a no-op — `buildSelfContext` returns null, all prompts fall through to current behavior.

## Test plan

- [x] `npm run test:coverage` — 397/397 passing, coverage 95.62% (CLAUDE.md threshold is 80%)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Asymmetric `isSelf` guards tested at both `generateCompetitorBrief` and `generateSelfBrief` entry points
- [x] Demo path: `buildSelfContext({ isDemo: true })` returns null, verified at call sites in both `generateBrief` and `runResearch`
- [x] `isSelf` exclusion tested for `listCompetitors` default; Intel Feed query scoped to non-self `competitorIds`
- [ ] Local smoke test after merge: `npm run db:seed && npm run bootstrap-new` — expect a Tabstack row with `is_self=true`, a self-profile brief populated, and the next competitor brief's `/generate` instructions containing the context block (verifiable via `api_logs`)