### PR TITLE
feat(config): expand Tabstack self pages

### DIFF
--- a/rivals.config.json
+++ b/rivals.config.json
@@ -3,7 +3,15 @@
     "name": "Tabstack",
     "slug": "tabstack",
     "url": "https://tabstack.ai",
-    "pages": [{ "label": "Homepage", "url": "https://tabstack.ai", "type": "homepage" }]
+    "pages": [
+      { "label": "Homepage", "url": "https://tabstack.ai", "type": "homepage" },
+      { "label": "Pricing", "url": "https://tabstack.ai/pricing", "type": "pricing", "geo_target": "US" },
+      { "label": "Docs", "url": "https://docs.tabstack.ai", "type": "docs" },
+      { "label": "Blog", "url": "https://tabstack.ai/blog", "type": "blog" },
+      { "label": "GitHub", "url": "https://github.com/Mozilla-Ocho/tabstack-typescript", "type": "github" },
+      { "label": "Twitter/X", "url": "https://x.com/tabstack", "type": "social" },
+      { "label": "Careers", "url": "https://www.mozilla.org/en-US/careers/listings/", "type": "careers" }
+    ]
   },
   "competitors": [
     {


### PR DESCRIPTION
## Summary
- Adds pricing, docs, blog, github, social, and careers pages to the Tabstack `self` block in `rivals.config.json`.
- Urls confirmed with @tessak22. Excluded: changelog, about page, reviews — no URL exists yet.

## Why
The self profile detail page (`/tabstack`) was rendering mostly-empty sections (Blog, Profile, Reviews) because only the homepage was configured. Self deserves the same depth of scanning that competitors get — same architecture, just needed the URLs.

## Test plan
- [x] JSON valid (`node -e 'JSON.parse(...)'`)
- [x] Prettier clean
- [x] rival-config parser tests still green (3/3)
- [x] typecheck clean
- [ ] After merge: seed upserts the new pages on next deploy; cron scans them on the next tick. Self-brief will regenerate with richer context from blog/pricing/careers signal.