### PR TITLE
feat(ui): site footer — open-source + powered by Tabstack

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1146,3 +1146,28 @@ body {
   display: grid;
   gap: 1rem;
 }
+
+/* ── Site Footer ─────────────────────────────────────────────────────── */
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 1.5rem 2rem 2rem;
+  border-top: 1px solid rgba(149, 167, 192, 0.12);
+  text-align: center;
+}
+.site-footer__line {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+.site-footer__link {
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-color: rgba(149, 167, 192, 0.35);
+  text-underline-offset: 3px;
+  transition: color 120ms ease;
+}
+.site-footer__link:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SiteFooter } from "@/components/SiteFooter";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,7 +14,10 @@ type RootLayoutProps = {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <SiteFooter />
+      </body>
     </html>
   );
 }

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,21 @@
+export function SiteFooter() {
+  return (
+    <footer className="site-footer">
+      <p className="site-footer__line">
+        Rival is an open-source competitive intelligence dashboard ·{" "}
+        <a
+          href="https://github.com/tessak22/rival"
+          className="site-footer__link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub
+        </a>{" "}
+        · Powered by{" "}
+        <a href="https://tabstack.ai" className="site-footer__link" target="_blank" rel="noopener noreferrer">
+          Tabstack
+        </a>
+      </p>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
One-line footer on every page noting Rival is open-source and powered by Tabstack. Linked to the repo and to tabstack.ai. Renders via the root layout so it appears on the dashboard, detail pages, insights, history — everywhere.

## Test plan
- [x] typecheck
- [x] prettier
- [x] tests (397)
- [x] build
- [ ] visual check after deploy