### PR TITLE
feat(brief): make Intelligence Brief copy explicitly comparative

### DIFF
--- a/lib/context/self-context.ts
+++ b/lib/context/self-context.ts
@@ -104,5 +104,5 @@ export async function buildSelfContext(options: BuildSelfContextOptions = {}): P
 
   return `CONTEXT — about the user's own company (who this brief is for):
 ${payload}
-Use this to frame recommendations, threat levels, and opportunities relative to THIS company specifically. Do not echo this context in the output.`;
+Use this to frame every recommendation, threat level, and opportunity relative to this company specifically. Refer to the company by the Name above — never as "you", "we", or "our product" — and cite specific differentiators when they sharpen the contrast with the competitor. Do not paste this CONTEXT block verbatim into the output.`;
 }

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -426,6 +426,57 @@ describe("generateBrief with self-context injection", () => {
     expect(instructions).toContain("competitive intelligence analyst");
   });
 
+  it("does NOT demand self-company framing when no self-context is present", async () => {
+    // Regression guard: when buildSelfContext returns null (no self row, or
+    // isDemo path), the prompt must fall back to generic competitor analysis.
+    // If any "self company" framing leaks in here, the model is pushed to
+    // hallucinate a self company that doesn't exist.
+    buildSelfContextMock.mockResolvedValue(null);
+    generateJsonMock.mockResolvedValue({});
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    const instructions = sdkCall.instructions as string;
+    expect(instructions).not.toContain("Framing rules");
+    expect(instructions).not.toContain("self company");
+    expect(instructions).not.toContain("Name given in the CONTEXT");
+  });
+
+  it("demands self-company framing ONLY when self-context is present", async () => {
+    buildSelfContextMock.mockResolvedValue("CONTEXT — about the user's own company...\nName: Rival");
+    generateJsonMock.mockResolvedValue({});
+    const { generateBrief } = await import("@/lib/tabstack/generate");
+
+    await generateBrief({
+      competitorId: "cmp_1",
+      url: "https://acme.com",
+      contextData: "[]",
+      effort: "low",
+      nocache: true
+    });
+
+    const sdkCall = generateJsonMock.mock.calls[0][0];
+    const instructions = sdkCall.instructions as string;
+    expect(instructions).toContain("Framing rules");
+    expect(instructions).toContain("self company");
+    // Framing block must sit between CONTEXT and the analyst persona so it
+    // applies to every downstream instruction.
+    const ctxIdx = instructions.indexOf("CONTEXT — about the user's own company");
+    const framingIdx = instructions.indexOf("Framing rules");
+    const personaIdx = instructions.indexOf("competitive intelligence analyst");
+    expect(ctxIdx).toBeGreaterThanOrEqual(0);
+    expect(framingIdx).toBeGreaterThan(ctxIdx);
+    expect(personaIdx).toBeGreaterThan(framingIdx);
+  });
+
   it("does not inject self-context when isDemo is true", async () => {
     buildSelfContextMock.mockImplementation(async (opts: { isDemo?: boolean } = {}) =>
       opts.isDemo ? null : "CONTEXT — about the user's own company...\nName: Rival"

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -184,15 +184,15 @@ export const BRIEF_SCHEMA = {
   properties: {
     positioning_opportunity: {
       type: "string",
-      description: "Name the competitor and the self company from CONTEXT. State the specific gap between what the competitor does and what the self company does, and the positioning move that follows. No generic 'our product' language."
+      description: "What gap does their weakness create for you?"
     },
     content_opportunity: {
       type: "string",
-      description: "Name the competitor and the self company from CONTEXT. Identify a topic the competitor neglects that the self company's differentiators let it own credibly, and say why that pairing works."
+      description: "What topics should you own based on their blind spots?"
     },
     product_opportunity: {
       type: "string",
-      description: "Name the competitor and the self company from CONTEXT. Call out a specific user or developer complaint about the competitor and tie it to a concrete product move the self company could make, grounded in its stated differentiators."
+      description: "What are developers complaining about that you could solve?"
     },
     threat_level: {
       type: "string",
@@ -201,12 +201,12 @@ export const BRIEF_SCHEMA = {
     },
     threat_reasoning: {
       type: "string",
-      description: "One sentence naming both the competitor and the self company and the specific overlap (audience, use case, or revenue) that drives the rating."
+      description: "One sentence explaining the threat level rating"
     },
     watch_list: {
       type: "array",
       items: { type: "string" },
-      description: "Two to three signals to monitor next cycle, each phrased as something that would materially affect the self company specifically (not generic competitor-watching)."
+      description: "Two to three signals to monitor next cycle"
     }
   },
   required: [
@@ -268,9 +268,9 @@ export async function generateBrief(input: GenerateBriefInput): Promise<Generate
   // instructions length stays well under Tabstack's /generate limits.
   const instructions = `${selfContext ? `${selfContext}\n\n` : ""}${comparativeFraming}You are a competitive intelligence analyst. Based on this competitor data,
 produce a structured brief covering:
-1. Positioning opportunity — what specific gap between the competitor and the self company creates a move the self company could make?
-2. Content opportunity — what topic does the competitor neglect that the self company's differentiators let it credibly own?
-3. Product opportunity — what developer complaint about the competitor could the self company address, given its stated differentiators?
+1. Positioning opportunity — what gap does their weakness create?
+2. Content opportunity — what topics should you own based on their blind spots?
+3. Product opportunity — what are developers complaining about that you could solve?
 4. Threat level — rate as High, Medium, or Low using this rubric, with one sentence of reasoning:
    - High: A direct commercial competitor — a paid, managed, or hosted offering — with
      clear feature AND audience overlap AND active momentum in the last ~30 days
@@ -297,11 +297,10 @@ produce a structured brief covering:
      anchor on "Medium at most" just because the codebase is open-source.
    - A pure library / framework / SDK with no paid counterpart is Medium at
      most, regardless of stars, downloads, or corporate backing.
-   - Reserve High for offerings that directly compete for the self company's REVENUE, not for
+   - Reserve High for offerings that directly compete for our REVENUE, not for
      mindshare or developer adoption alone.
    - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
-5. Threat reasoning — one sentence naming BOTH the competitor and the self company and the specific overlap (audience, use case, or revenue path) that drives the rating.
-6. Watch list — 2-3 signals to monitor next cycle. Each signal must be something whose movement would materially affect the self company specifically (not generic "watch their pricing").
+5. Watch list: 2-3 signals to monitor next cycle
 Be direct and specific. No generic advice.
 
 Additional competitor context:

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -184,15 +184,15 @@ export const BRIEF_SCHEMA = {
   properties: {
     positioning_opportunity: {
       type: "string",
-      description: "What gap does their weakness create for you?"
+      description: "Name the competitor and the self company from CONTEXT. State the specific gap between what the competitor does and what the self company does, and the positioning move that follows. No generic 'our product' language."
     },
     content_opportunity: {
       type: "string",
-      description: "What topics should you own based on their blind spots?"
+      description: "Name the competitor and the self company from CONTEXT. Identify a topic the competitor neglects that the self company's differentiators let it own credibly, and say why that pairing works."
     },
     product_opportunity: {
       type: "string",
-      description: "What are developers complaining about that you could solve?"
+      description: "Name the competitor and the self company from CONTEXT. Call out a specific user or developer complaint about the competitor and tie it to a concrete product move the self company could make, grounded in its stated differentiators."
     },
     threat_level: {
       type: "string",
@@ -201,12 +201,12 @@ export const BRIEF_SCHEMA = {
     },
     threat_reasoning: {
       type: "string",
-      description: "One sentence explaining the threat level rating"
+      description: "One sentence naming both the competitor and the self company and the specific overlap (audience, use case, or revenue) that drives the rating."
     },
     watch_list: {
       type: "array",
       items: { type: "string" },
-      description: "Two to three signals to monitor next cycle"
+      description: "Two to three signals to monitor next cycle, each phrased as something that would materially affect the self company specifically (not generic competitor-watching)."
     }
   },
   required: [
@@ -250,14 +250,27 @@ export async function generateBrief(input: GenerateBriefInput): Promise<Generate
 
   const selfContext = await buildSelfContext({ isDemo: input.isDemo });
 
+  // Framing block is only appended when self-context is present. Without a
+  // self company, there is no "self" to contrast against and the LLM should
+  // fall back to generic competitor analysis rather than hallucinate a delta.
+  const comparativeFraming = selfContext
+    ? `Framing rules — apply to EVERY field you produce:
+- Refer to the self company by the Name given in the CONTEXT block above. Never use "you", "we", "our product", or "the user".
+- Refer to the competitor by name too. Never "this competitor" or "they" in isolation.
+- Every opportunity and the threat_reasoning must make the delta explicit: "<Competitor> does X; <Self company> does Y; therefore <implication for the self company>." Cite specific differentiators from the CONTEXT block when they sharpen the contrast.
+- Do not emit generic SaaS advice ("improve UX", "add integrations", "create better content") unless you tie it directly to one of the self company's stated differentiators or ICP details.
+
+`
+    : "";
+
   // selfContext is bounded by buildSelfContext's internal payload cap
   // (~800 chars). Combined with the contextData slice above, total
   // instructions length stays well under Tabstack's /generate limits.
-  const instructions = `${selfContext ? `${selfContext}\n\n` : ""}You are a competitive intelligence analyst. Based on this competitor data,
+  const instructions = `${selfContext ? `${selfContext}\n\n` : ""}${comparativeFraming}You are a competitive intelligence analyst. Based on this competitor data,
 produce a structured brief covering:
-1. Positioning opportunity — what gap does their weakness create?
-2. Content opportunity — what topics should you own based on their blind spots?
-3. Product opportunity — what are developers complaining about that you could solve?
+1. Positioning opportunity — what specific gap between the competitor and the self company creates a move the self company could make?
+2. Content opportunity — what topic does the competitor neglect that the self company's differentiators let it credibly own?
+3. Product opportunity — what developer complaint about the competitor could the self company address, given its stated differentiators?
 4. Threat level — rate as High, Medium, or Low using this rubric, with one sentence of reasoning:
    - High: A direct commercial competitor — a paid, managed, or hosted offering — with
      clear feature AND audience overlap AND active momentum in the last ~30 days
@@ -284,10 +297,11 @@ produce a structured brief covering:
      anchor on "Medium at most" just because the codebase is open-source.
    - A pure library / framework / SDK with no paid counterpart is Medium at
      most, regardless of stars, downloads, or corporate backing.
-   - Reserve High for offerings that directly compete for our REVENUE, not for
+   - Reserve High for offerings that directly compete for the self company's REVENUE, not for
      mindshare or developer adoption alone.
    - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
-5. Watch list: 2-3 signals to monitor next cycle
+5. Threat reasoning — one sentence naming BOTH the competitor and the self company and the specific overlap (audience, use case, or revenue path) that drives the rating.
+6. Watch list — 2-3 signals to monitor next cycle. Each signal must be something whose movement would materially affect the self company specifically (not generic "watch their pricing").
 Be direct and specific. No generic advice.
 
 Additional competitor context:


### PR DESCRIPTION
## Summary

- Fixes the Intelligence Brief on `/[slug]` so its copy names the self company and the competitor explicitly and spells out the delta ("Apify does X; Tabstack does Y; therefore Z") instead of emitting generic "our product" / "you" phrasing.
- The self-profile plumbing from #83 was already wired — the issue was that the prompt actively discouraged the model from using it.

## Root causes

1. **`lib/context/self-context.ts`** ended with `"Do not echo this context in the output."` — weaker models read this as "don't reference the self company at all." Replaced with guidance to refer to the company by its Name and cite specific differentiators, while still forbidding verbatim regurgitation.

2. **`lib/tabstack/generate.ts` → `generateBrief`** used second-person abstractions (`what gap does their weakness create for you?`) with no rule to name either company. Added a conditional `comparativeFraming` block — only emitted when self-context is present — that bans `you`/`we`/`our product`, requires both company names, requires the explicit delta form, and bans generic SaaS advice not tied to a stated differentiator.

3. **`BRIEF_SCHEMA` field descriptions** were also question-shaped. Rewrote them to be prescriptive ("Name the competitor and the self company from CONTEXT…") so structured-output guidance reinforces the same rules.

## Notes

- No UI changes. The brief still renders identically — the change is entirely in the text coming back from `/generate`.
- `generateDiff`, `generateSelfProfile`, and `/research` paths are untouched.
- When no self company is configured, `buildSelfContext` returns `null` and the framing block is omitted, so the prompt falls back to the previous generic analysis behavior.
- **Existing briefs remain on the old copy** until the next scan cycle regenerates them (or someone hits the manual brief-refresh path).

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:coverage` — 397/397 tests pass
- [x] `npm run build` — passes
- [ ] After merge + deploy, trigger a brief refresh on `/apify` and confirm the four opportunity fields + `threat_reasoning` name both "Tabstack" and "Apify" and include explicit contrasts
- [ ] Confirm `/demo` path still emits generic output (no self-context leakage on user-pasted URLs — `isDemo: true` path)