### PR TITLE
fix(matrix): include self competitor on positioning matrix (#70)

### DIFF
--- a/app/matrix/page.tsx
+++ b/app/matrix/page.tsx
@@ -33,7 +33,7 @@ export default async function MatrixPage() {
 
   const competitors = await prisma.competitor.findMany({
     select: { id: true, name: true, slug: true, intelligenceBrief: true, isSelf: true },
-    orderBy: [{ isSelf: "desc" }, { name: "asc" }]
+    orderBy: [{ isSelf: "asc" }, { name: "asc" }]
   });
 
   const points: MatrixPoint[] = [];
@@ -49,7 +49,7 @@ export default async function MatrixPage() {
     points.push({ name: c.name, slug: c.slug, x, y, isSelf: c.isSelf });
   }
 
-  const hasEnoughData = points.length >= 2;
+  const hasEnoughData = points.some((p) => !p.isSelf);
 
   return (
     <RDSPageShell>
@@ -82,7 +82,7 @@ export default async function MatrixPage() {
               ? `${missingScores} competitor${missingScores === 1 ? "" : "s"} ${
                   missingScores === 1 ? "has" : "have"
                 } no brief scores yet. Re-generate briefs to populate the matrix.`
-              : "Add at least 2 competitors and generate their intelligence briefs to see the positioning matrix."
+              : "Generate intelligence briefs for at least 1 competitor to see the positioning matrix."
           }
         />
       ) : (

--- a/app/matrix/page.tsx
+++ b/app/matrix/page.tsx
@@ -32,9 +32,8 @@ export default async function MatrixPage() {
   }
 
   const competitors = await prisma.competitor.findMany({
-    where: { isSelf: false },
-    select: { id: true, name: true, slug: true, intelligenceBrief: true },
-    orderBy: { name: "asc" }
+    select: { id: true, name: true, slug: true, intelligenceBrief: true, isSelf: true },
+    orderBy: [{ isSelf: "desc" }, { name: "asc" }]
   });
 
   const points: MatrixPoint[] = [];
@@ -47,7 +46,7 @@ export default async function MatrixPage() {
       missingScores++;
       continue;
     }
-    points.push({ name: c.name, slug: c.slug, x, y });
+    points.push({ name: c.name, slug: c.slug, x, y, isSelf: c.isSelf });
   }
 
   const hasEnoughData = points.length >= 2;

--- a/components/matrix/PositioningMatrix.tsx
+++ b/components/matrix/PositioningMatrix.tsx
@@ -5,6 +5,7 @@ export type MatrixPoint = {
   slug: string;
   x: number; // 0–10
   y: number; // 0–10
+  isSelf?: boolean;
 };
 
 type Props = {
@@ -122,15 +123,23 @@ export function PositioningMatrix({ points, config }: Props) {
         const nearRight = cx > M + PLOT - 90;
         return (
           <g key={pt.slug}>
-            <circle cx={cx} cy={cy} r={6} fill="var(--ink)" />
+            {pt.isSelf ? (
+              <>
+                <circle cx={cx} cy={cy} r={8} fill="var(--paper)" stroke="var(--ink)" strokeWidth={2} />
+                <circle cx={cx} cy={cy} r={4} fill="var(--ink)" />
+              </>
+            ) : (
+              <circle cx={cx} cy={cy} r={6} fill="var(--ink)" />
+            )}
             <text
-              x={nearRight ? cx - 10 : cx + 10}
+              x={nearRight ? cx - 12 : cx + 12}
               y={cy + 4}
               textAnchor={nearRight ? "end" : "start"}
               fill="var(--ink)"
               style={{ fontSize: 12, fontFamily: "var(--font-sans)", fontWeight: 600, letterSpacing: "-0.01em" }}
             >
               {pt.name}
+              {pt.isSelf && " ★"}
             </text>
           </g>
         );

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -401,9 +401,50 @@ export const SELF_PROFILE_SCHEMA = {
       type: "array",
       items: { type: "string" },
       description: "3–5 bullets of recent changes visible from changelog, blog, or careers."
+    },
+    openness_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "0 = fully open source, transparent, no lock-in; 10 = fully proprietary, closed, high lock-in"
+    },
+    brand_trust_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "0 = low brand recognition and trust; 10 = high brand recognition and trust"
+    },
+    pricing_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "0 = entirely free or open source; 10 = premium or enterprise pricing only"
+    },
+    market_maturity_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "0 = early-stage or emerging; 10 = established and mature market presence"
+    },
+    feature_breadth_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description: "0 = narrow specialist with a single focused use case; 10 = broad generalist covering many use cases"
     }
   },
-  required: ["positioning_summary", "icp_summary", "pricing_summary", "differentiators", "recent_signals"]
+  required: [
+    "positioning_summary",
+    "icp_summary",
+    "pricing_summary",
+    "differentiators",
+    "recent_signals",
+    "openness_score",
+    "brand_trust_score",
+    "pricing_score",
+    "market_maturity_score",
+    "feature_breadth_score"
+  ]
 } as const;
 
 export const SELF_PROFILE_EXPECTED_FIELDS: string[] = [...SELF_PROFILE_SCHEMA.required];
@@ -437,6 +478,11 @@ Produce:
 3. pricing_summary — monetization model in one short paragraph.
 4. differentiators — 3–5 bullets of what makes them distinct (not marketing fluff).
 5. recent_signals — 3–5 bullets of recent changes visible in changelog, blog, or careers.
+6. Positioning axis scores — using only the data provided, rate each of the five
+   dimensions on a 0–10 scale as defined in the output schema: openness_score,
+   brand_trust_score, pricing_score, market_maturity_score, feature_breadth_score.
+   Base each score on explicit signals in the data; do not use general market
+   knowledge as a substitute for absent data.
 
 Be direct and specific. No generic commentary. Do not speculate — only describe
 what the data shows.


### PR DESCRIPTION
## Summary

Hotfix for #70 — Tabstack (the self competitor) was missing from `/matrix` because:

- The page query had `where: { isSelf: false }` filtering it out
- `SELF_PROFILE_SCHEMA` didn't include the 5 axis score fields, so `generateSelfBrief` never produced them

## Changes

- `lib/tabstack/generate.ts` — Added 5 axis score fields to `SELF_PROFILE_SCHEMA` + instruction item 6 in `generateSelfProfile`
- `app/matrix/page.tsx` — Removed `isSelf: false` filter; self competitor now included
- `components/matrix/PositioningMatrix.tsx` — Self dot rendered as a bullseye (outlined ring + center dot) with a ★ suffix on the name label to distinguish it from competitors

## After merging

Run `npm run refresh-briefs` (or trigger via the self brief API) to regenerate Tabstack's brief with the new axis scores.

## Test Plan

- [ ] `npm run test` — 406 passing
- [ ] `npm run typecheck` — clean
- [ ] Re-run self brief, verify `/matrix` plots Tabstack with bullseye style