### PR TITLE
feat(matrix): buyer-decision axes — managed service vs LLM included

### DIFF
--- a/lib/config/rival-config.ts
+++ b/lib/config/rival-config.ts
@@ -6,7 +6,9 @@ export type MatrixAxisKey =
   | "brand_trust_score"
   | "pricing_score"
   | "market_maturity_score"
-  | "feature_breadth_score";
+  | "feature_breadth_score"
+  | "managed_service_score"
+  | "llm_included_score";
 
 export type MatrixAxisConfig = {
   key: MatrixAxisKey;
@@ -28,13 +30,13 @@ export type MatrixConfig = {
 };
 
 export const DEFAULT_MATRIX_CONFIG: MatrixConfig = {
-  x_axis: { key: "openness_score", label_low: "Open Source", label_high: "Proprietary" },
-  y_axis: { key: "brand_trust_score", label_low: "Low Trust", label_high: "High Trust" },
+  x_axis: { key: "managed_service_score", label_low: "Self-hosted", label_high: "Managed API" },
+  y_axis: { key: "llm_included_score", label_low: "Bring Your Own LLM", label_high: "LLM Built-in" },
   quadrant_labels: {
-    top_left: "Trusted OSS",
-    top_right: "Established Leaders",
-    bottom_left: "Emerging Players",
-    bottom_right: "Niche Specialists"
+    top_left: "DIY + AI-Ready",
+    top_right: "Managed + AI-Ready",
+    bottom_left: "DIY + Traditional",
+    bottom_right: "Managed + Traditional"
   }
 };
 
@@ -78,7 +80,9 @@ const VALID_AXIS_KEYS = new Set<MatrixAxisKey>([
   "brand_trust_score",
   "pricing_score",
   "market_maturity_score",
-  "feature_breadth_score"
+  "feature_breadth_score",
+  "managed_service_score",
+  "llm_included_score"
 ]);
 
 function isValidAxisKey(key: unknown): key is MatrixAxisKey {

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -510,7 +510,7 @@ describe("generateBrief with self-context injection", () => {
 });
 
 describe("BRIEF_SCHEMA axis scores", () => {
-  it("includes all five axis score fields as number type", async () => {
+  it("includes all seven axis score fields as number type", async () => {
     const { BRIEF_SCHEMA } = await import("@/lib/tabstack/generate");
     const props = BRIEF_SCHEMA.properties as Record<string, { type: string; minimum?: number; maximum?: number }>;
     const axisFields = [
@@ -518,7 +518,9 @@ describe("BRIEF_SCHEMA axis scores", () => {
       "brand_trust_score",
       "pricing_score",
       "market_maturity_score",
-      "feature_breadth_score"
+      "feature_breadth_score",
+      "managed_service_score",
+      "llm_included_score"
     ];
     for (const field of axisFields) {
       expect(props[field], `${field} missing from BRIEF_SCHEMA`).toBeDefined();
@@ -528,14 +530,16 @@ describe("BRIEF_SCHEMA axis scores", () => {
     }
   });
 
-  it("includes all five axis score fields in BRIEF_EXPECTED_FIELDS", async () => {
+  it("includes all seven axis score fields in BRIEF_EXPECTED_FIELDS", async () => {
     const { BRIEF_EXPECTED_FIELDS } = await import("@/lib/tabstack/generate");
     for (const field of [
       "openness_score",
       "brand_trust_score",
       "pricing_score",
       "market_maturity_score",
-      "feature_breadth_score"
+      "feature_breadth_score",
+      "managed_service_score",
+      "llm_included_score"
     ]) {
       expect(BRIEF_EXPECTED_FIELDS).toContain(field);
     }

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -237,6 +237,20 @@ export const BRIEF_SCHEMA = {
       minimum: 0,
       maximum: 10,
       description: "0 = narrow specialist with a single focused use case; 10 = broad generalist covering many use cases"
+    },
+    managed_service_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description:
+        "0 = fully self-hosted library or framework the user runs themselves; 10 = fully managed cloud API with no infrastructure to operate"
+    },
+    llm_included_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description:
+        "0 = no LLM or AI capabilities included, user must bring their own; 10 = LLM and AI capabilities fully built in and ready to use"
     }
   },
   required: [
@@ -250,7 +264,9 @@ export const BRIEF_SCHEMA = {
     "brand_trust_score",
     "pricing_score",
     "market_maturity_score",
-    "feature_breadth_score"
+    "feature_breadth_score",
+    "managed_service_score",
+    "llm_included_score"
   ]
 } as const;
 
@@ -337,10 +353,11 @@ produce a structured brief covering:
    - When evidence is mixed, sparse, or ambiguous, default to Medium rather than High.
 5. Watch list: 2-3 signals to monitor next cycle
 6. Positioning axis scores — using only the competitor data provided, rate each
-   of the five dimensions on a 0–10 scale as defined in the output schema:
+   of the seven dimensions on a 0–10 scale as defined in the output schema:
    openness_score, brand_trust_score, pricing_score, market_maturity_score,
-   feature_breadth_score. Base each score on explicit signals in the data;
-   do not use general market knowledge as a substitute for absent data.
+   feature_breadth_score, managed_service_score, llm_included_score. Base each
+   score on explicit signals in the data; do not use general market knowledge
+   as a substitute for absent data.
 Be direct and specific. No generic advice.
 
 Additional competitor context:
@@ -431,6 +448,20 @@ export const SELF_PROFILE_SCHEMA = {
       minimum: 0,
       maximum: 10,
       description: "0 = narrow specialist with a single focused use case; 10 = broad generalist covering many use cases"
+    },
+    managed_service_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description:
+        "0 = fully self-hosted library or framework the user runs themselves; 10 = fully managed cloud API with no infrastructure to operate"
+    },
+    llm_included_score: {
+      type: "number",
+      minimum: 0,
+      maximum: 10,
+      description:
+        "0 = no LLM or AI capabilities included, user must bring their own; 10 = LLM and AI capabilities fully built in and ready to use"
     }
   },
   required: [
@@ -443,7 +474,9 @@ export const SELF_PROFILE_SCHEMA = {
     "brand_trust_score",
     "pricing_score",
     "market_maturity_score",
-    "feature_breadth_score"
+    "feature_breadth_score",
+    "managed_service_score",
+    "llm_included_score"
   ]
 } as const;
 
@@ -478,11 +511,11 @@ Produce:
 3. pricing_summary — monetization model in one short paragraph.
 4. differentiators — 3–5 bullets of what makes them distinct (not marketing fluff).
 5. recent_signals — 3–5 bullets of recent changes visible in changelog, blog, or careers.
-6. Positioning axis scores — using only the data provided, rate each of the five
+6. Positioning axis scores — using only the data provided, rate each of the seven
    dimensions on a 0–10 scale as defined in the output schema: openness_score,
-   brand_trust_score, pricing_score, market_maturity_score, feature_breadth_score.
-   Base each score on explicit signals in the data; do not use general market
-   knowledge as a substitute for absent data.
+   brand_trust_score, pricing_score, market_maturity_score, feature_breadth_score,
+   managed_service_score, llm_included_score. Base each score on explicit signals
+   in the data; do not use general market knowledge as a substitute for absent data.
 
 Be direct and specific. No generic commentary. Do not speculate — only describe
 what the data shows.

--- a/rivals.config.json
+++ b/rivals.config.json
@@ -148,20 +148,20 @@
   "manual_stale_days": 30,
   "matrix": {
     "x_axis": {
-      "key": "openness_score",
-      "label_low": "Open Source",
-      "label_high": "Proprietary"
+      "key": "managed_service_score",
+      "label_low": "Self-hosted",
+      "label_high": "Managed API"
     },
     "y_axis": {
-      "key": "brand_trust_score",
-      "label_low": "Low Trust",
-      "label_high": "High Trust"
+      "key": "llm_included_score",
+      "label_low": "Bring Your Own LLM",
+      "label_high": "LLM Built-in"
     },
     "quadrant_labels": {
-      "top_left": "Trusted OSS",
-      "top_right": "Established Leaders",
-      "bottom_left": "Emerging Players",
-      "bottom_right": "Niche Specialists"
+      "top_left": "DIY + AI-Ready",
+      "top_right": "Managed + AI-Ready",
+      "bottom_left": "DIY + Traditional",
+      "bottom_right": "Managed + Traditional"
     }
   },
   "notifications": {


### PR DESCRIPTION
## Summary

Adds two new positioning dimensions purpose-built for buyer self-selection in the web automation / AI agent space, and swaps the default matrix config to use them.

- **`managed_service_score`** — Self-hosted library → Fully managed cloud API
- **`llm_included_score`** — Bring your own LLM → LLM/AI fully built in

Quadrants:
| | Self-hosted | Managed API |
|---|---|---|
| **LLM Built-in** | DIY + AI-Ready | Managed + AI-Ready ← Tabstack |
| **BYOLLM** | DIY + Traditional | Managed + Traditional |

Both fields added to `BRIEF_SCHEMA`, `SELF_PROFILE_SCHEMA`, and both instruction prompts. `MatrixAxisKey` union and `VALID_AXIS_KEYS` updated. `DEFAULT_MATRIX_CONFIG` and `rivals.config.json` swapped to the new axes.

After merging: re-run `npm run refresh-briefs` to populate the new scores.

## Test Plan
- [ ] 406 tests pass, typecheck clean
- [ ] Re-run briefs, verify `/matrix` shows new quadrant labels and correct competitor placement