### PR TITLE
fix(deep-dive): stream events progressively, fix params, RDS redesign

### DIFF
--- a/app/[slug]/deep-dive/page.tsx
+++ b/app/[slug]/deep-dive/page.tsx
@@ -1,11 +1,15 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { DeepDiveClient } from "@/components/deep-dive/DeepDiveClient";
+import { RDSPageShell, RDSHeader, RDSFooter, RDSSectionHead, RDSKicker, RDSEmpty, RDSChip } from "@/components/rds";
 import { prisma } from "@/lib/db/client";
 import { DEEP_DIVE_TEMPLATES } from "@/lib/deep-dive-templates";
 
+export const dynamic = "force-dynamic";
+
 type PageProps = {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 };
 
 function getTemplateLabel(promptTemplate: string | null): string {
@@ -15,15 +19,13 @@ function getTemplateLabel(promptTemplate: string | null): string {
 }
 
 export default async function DeepDivePage({ params }: PageProps) {
-  const { slug } = params;
+  const { slug } = await params;
   const competitor = await prisma.competitor.findUnique({
     where: { slug },
     select: { id: true, name: true, baseUrl: true }
   });
 
-  if (!competitor) {
-    notFound();
-  }
+  if (!competitor) notFound();
 
   const previousDeepDives = await prisma.deepDive.findMany({
     where: { competitorId: competitor.id },
@@ -32,39 +34,103 @@ export default async function DeepDivePage({ params }: PageProps) {
   });
 
   return (
-    <main className="dashboard-page">
-      <header className="page-header">
-        <h1>{competitor.name} Deep Dive</h1>
-        <p>{competitor.baseUrl}</p>
-      </header>
+    <RDSPageShell>
+      <RDSHeader
+        left={
+          <Link
+            href={`/${slug}`}
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-11)",
+              color: "var(--ink-faint)",
+              letterSpacing: "0.08em",
+              textDecoration: "none",
+              textTransform: "uppercase"
+            }}
+          >
+            ← {competitor.name}
+          </Link>
+        }
+      />
+
+      <div style={{ marginBottom: 28 }}>
+        <RDSKicker>{competitor.name}</RDSKicker>
+        <h1
+          style={{
+            margin: "6px 0 4px",
+            fontSize: "var(--fs-28)",
+            fontWeight: 700,
+            fontFamily: "var(--font-serif)",
+            letterSpacing: "var(--tr-snug)"
+          }}
+        >
+          Deep Dive
+        </h1>
+        <p style={{ margin: 0, color: "var(--ink-mute)", fontSize: "var(--fs-14)" }}>
+          Autonomous multi-pass research — powered by Tabstack /research
+        </p>
+      </div>
 
       <DeepDiveClient competitorId={competitor.id} competitorName={competitor.name} />
 
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Previous Deep Dives</h2>
-        </header>
+      <div style={{ marginTop: 40 }}>
+        <RDSSectionHead title="Previous Deep Dives" count={previousDeepDives.length} />
         {previousDeepDives.length === 0 ? (
-          <p className="muted">No previous deep dives yet.</p>
+          <RDSEmpty title="No previous deep dives" body="Run your first deep dive above." />
         ) : (
-          <ul className="stat-list">
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {previousDeepDives.map((item) => (
-              <li key={item.id}>
-                <span>{item.mode}</span>
-                <strong>
-                  {item.createdAt.toLocaleString()}
-                  <span className="template-badge">{getTemplateLabel(item.promptTemplate)}</span>
-                </strong>
+              <div key={item.id} style={{ border: "1px solid var(--paper-rule)", padding: "14px 16px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+                  <RDSChip>{item.mode}</RDSChip>
+                  <RDSChip>{getTemplateLabel(item.promptTemplate)}</RDSChip>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-11)",
+                      color: "var(--ink-faint)",
+                      marginLeft: "auto"
+                    }}
+                  >
+                    {item.createdAt.toLocaleString("en-US", {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                      timeZone: "UTC"
+                    })}{" "}
+                    UTC
+                  </span>
+                </div>
                 {item.result ? (
-                  <p className="muted">{JSON.stringify(item.result).replace(/\s+/g, " ").slice(0, 180)}...</p>
+                  <p
+                    style={{
+                      margin: 0,
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-12)",
+                      color: "var(--ink-mute)",
+                      lineHeight: "var(--lh-body)"
+                    }}
+                  >
+                    {JSON.stringify(item.result).replace(/\s+/g, " ").slice(0, 200)}…
+                  </p>
                 ) : (
-                  <p className="muted">No saved result payload.</p>
+                  <p
+                    style={{
+                      margin: 0,
+                      color: "var(--ink-faint)",
+                      fontSize: "var(--fs-12)",
+                      fontFamily: "var(--font-mono)"
+                    }}
+                  >
+                    No saved result.
+                  </p>
                 )}
-              </li>
+              </div>
             ))}
-          </ul>
+          </div>
         )}
-      </section>
-    </main>
+      </div>
+
+      <RDSFooter />
+    </RDSPageShell>
   );
 }

--- a/app/api/__tests__/deep-dive.route.test.ts
+++ b/app/api/__tests__/deep-dive.route.test.ts
@@ -1,26 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { runResearchMock, competitorFindUniqueMock, deepDiveCreateMock } = vi.hoisted(() => ({
-  runResearchMock: vi.fn(),
-  competitorFindUniqueMock: vi.fn(),
-  deepDiveCreateMock: vi.fn()
+const { researchMock, competitorFindUniqueMock, deepDiveCreateMock, apiLogCreateMock, buildSelfContextMock } =
+  vi.hoisted(() => ({
+    researchMock: vi.fn(),
+    competitorFindUniqueMock: vi.fn(),
+    deepDiveCreateMock: vi.fn(),
+    apiLogCreateMock: vi.fn(),
+    buildSelfContextMock: vi.fn().mockResolvedValue(null)
+  }));
+
+vi.mock("@/lib/tabstack/client", () => ({
+  getTabstackClient: () => ({ agent: { research: researchMock } })
 }));
 
-vi.mock("@/lib/tabstack/research", () => ({ runResearch: runResearchMock }));
+vi.mock("@/lib/context/self-context", () => ({
+  buildSelfContext: buildSelfContextMock
+}));
+
 vi.mock("@/lib/db/client", () => ({
   prisma: {
     competitor: { findUnique: competitorFindUniqueMock },
-    deepDive: { create: deepDiveCreateMock }
+    deepDive: { create: deepDiveCreateMock },
+    apiLog: { create: apiLogCreateMock }
   }
 }));
 
-const COMPETITOR = { id: "cmp_1", name: "Acme" };
-const RESEARCH_RESULT = {
-  result: { summary: "Acme is a strong competitor" },
-  citations: ["https://example.com"],
-  events: [{ event: "progress", data: "Researching..." }]
-};
+// Async generator that mimics the Tabstack research stream
+async function* mockStream() {
+  yield { event: "progress", data: "Researching..." };
+  yield { event: "complete", data: { result: { summary: "Acme is a strong competitor" }, citations: [] } };
+}
+
+const COMPETITOR = { id: "cmp_1", name: "Acme", baseUrl: "https://acme.com" };
 
 function jsonRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost/api/deep-dive", {
@@ -32,12 +44,17 @@ function jsonRequest(body: unknown): NextRequest {
 
 describe("POST /api/deep-dive", () => {
   beforeEach(() => {
-    runResearchMock.mockReset();
+    vi.resetModules();
+    researchMock.mockReset();
     competitorFindUniqueMock.mockReset();
     deepDiveCreateMock.mockReset();
-    runResearchMock.mockResolvedValue(RESEARCH_RESULT);
+    apiLogCreateMock.mockReset();
+    buildSelfContextMock.mockReset();
+    researchMock.mockReturnValue(mockStream());
     competitorFindUniqueMock.mockResolvedValue(COMPETITOR);
     deepDiveCreateMock.mockResolvedValue({});
+    apiLogCreateMock.mockResolvedValue({});
+    buildSelfContextMock.mockResolvedValue(null);
   });
 
   it("returns 400 when competitorId is missing", async () => {
@@ -62,15 +79,16 @@ describe("POST /api/deep-dive", () => {
     expect(res.headers.get("content-type")).toBe("text/event-stream");
   });
 
-  it("defaults mode to balanced", async () => {
+  it("defaults mode to balanced and passes nocache: true to SDK", async () => {
     const { POST } = await import("@/app/api/deep-dive/route");
     await POST(jsonRequest({ competitorId: "cmp_1" }));
-    expect(runResearchMock).toHaveBeenCalledWith(expect.objectContaining({ mode: "balanced", nocache: true }));
+    expect(researchMock).toHaveBeenCalledWith(expect.objectContaining({ mode: "balanced", nocache: true }));
   });
 
   it("respects provided mode", async () => {
+    researchMock.mockReturnValue(mockStream());
     const { POST } = await import("@/app/api/deep-dive/route");
     await POST(jsonRequest({ competitorId: "cmp_1", mode: "fast" }));
-    expect(runResearchMock).toHaveBeenCalledWith(expect.objectContaining({ mode: "fast" }));
+    expect(researchMock).toHaveBeenCalledWith(expect.objectContaining({ mode: "fast" }));
   });
 });

--- a/app/api/deep-dive/route.ts
+++ b/app/api/deep-dive/route.ts
@@ -2,7 +2,9 @@ import type { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/db/client";
-import { runResearch } from "@/lib/tabstack/research";
+import { getTabstackClient } from "@/lib/tabstack/client";
+import { buildSelfContext } from "@/lib/context/self-context";
+import { extractResult, extractCitations } from "@/lib/tabstack/research";
 import { buildPromptForTemplate } from "@/lib/deep-dive-templates";
 
 type DeepDiveRequest = {
@@ -56,56 +58,76 @@ export async function POST(request: NextRequest) {
     });
   }
 
+  const client = getTabstackClient();
+
   const stream = new ReadableStream({
     start: async (controller) => {
+      const startTime = Date.now();
+      let status: "success" | "error" = "success";
+      let rawError: string | undefined;
+
       try {
         controller.enqueue(sse("research:started", { competitorId: competitor.id, mode, promptTemplate }));
 
-        // If a known template key is provided, use its prompt; otherwise fall back to general research
-        const builtPrompt = promptTemplate ? buildPromptForTemplate(promptTemplate, competitor.name) : null;
-        const query = builtPrompt ?? buildResearchQuery(competitor.name);
+        // Build query — inject self context for comparative framing, same as runResearch
+        const selfContext = await buildSelfContext({ isDemo: false });
+        const baseQuery =
+          (promptTemplate ? buildPromptForTemplate(promptTemplate, competitor.name) : null) ??
+          buildResearchQuery(competitor.name);
+        const query = selfContext ? `${selfContext}\n\nRESEARCH QUESTION:\n${baseQuery}` : baseQuery;
 
-        const result = await runResearch({
-          competitorId: competitor.id,
-          query,
-          mode,
-          nocache: true,
-          isDemo: false
-        });
+        // Stream directly from SDK — each event is forwarded immediately, avoiding timeout
+        const researchStream = await client.agent.research({ query, mode: mode as "fast" | "balanced", nocache: true });
 
-        for (const event of result.events) {
-          controller.enqueue(
-            sse("research:progress", {
-              event: event.event ?? "unknown",
-              data: event.data
-            })
-          );
+        let completeEventData: unknown = undefined;
+
+        for await (const event of researchStream) {
+          controller.enqueue(sse("research:progress", { event: event.event ?? "unknown", data: event.data }));
+
+          if (event.event === "complete") {
+            completeEventData = event.data;
+          }
+          if (event.event === "error") {
+            status = "error";
+            rawError = typeof event.data === "string" ? event.data : JSON.stringify(event.data);
+            break;
+          }
         }
+
+        const result = extractResult(completeEventData);
+        const citations = extractCitations(completeEventData);
 
         await prisma.deepDive.create({
           data: {
             competitorId: competitor.id,
-            mode,
+            mode: mode as string,
             query,
-            result: toJsonValue(result.result),
-            citations: toJsonValue(result.citations),
-            promptTemplate
+            result: toJsonValue(result),
+            citations: toJsonValue(citations),
+            promptTemplate: promptTemplate ?? null
           }
         });
 
-        controller.enqueue(
-          sse("research:complete", {
-            result: result.result,
-            citations: result.citations
-          })
-        );
+        controller.enqueue(sse("research:complete", { result, citations }));
       } catch (error) {
-        controller.enqueue(
-          sse("research:error", {
-            error: error instanceof Error ? error.message : "Deep dive failed"
-          })
-        );
+        status = "error";
+        rawError = error instanceof Error ? error.message : "Deep dive failed";
+        controller.enqueue(sse("research:error", { error: rawError }));
       } finally {
+        // Log to api_logs manually — logger.call can't wrap a live-streaming path
+        await prisma.apiLog.create({
+          data: {
+            competitorId: competitor.id,
+            endpoint: "research",
+            mode,
+            nocache: true,
+            status,
+            rawError: rawError ?? null,
+            durationMs: Date.now() - startTime,
+            resultQuality: status === "success" ? "full" : "empty",
+            isDemo: false
+          }
+        });
         controller.close();
       }
     }

--- a/app/api/deep-dive/route.ts
+++ b/app/api/deep-dive/route.ts
@@ -94,40 +94,48 @@ export async function POST(request: NextRequest) {
           }
         }
 
-        const result = extractResult(completeEventData);
-        const citations = extractCitations(completeEventData);
+        if (status === "error") {
+          controller.enqueue(sse("research:error", { error: rawError }));
+        } else {
+          const result = extractResult(completeEventData);
+          const citations = extractCitations(completeEventData);
 
-        await prisma.deepDive.create({
-          data: {
-            competitorId: competitor.id,
-            mode: mode as string,
-            query,
-            result: toJsonValue(result),
-            citations: toJsonValue(citations),
-            promptTemplate: promptTemplate ?? null
-          }
-        });
+          await prisma.deepDive.create({
+            data: {
+              competitorId: competitor.id,
+              mode: mode as string,
+              query,
+              result: toJsonValue(result),
+              citations: toJsonValue(citations),
+              promptTemplate: promptTemplate ?? null
+            }
+          });
 
-        controller.enqueue(sse("research:complete", { result, citations }));
+          controller.enqueue(sse("research:complete", { result, citations }));
+        }
       } catch (error) {
         status = "error";
         rawError = error instanceof Error ? error.message : "Deep dive failed";
         controller.enqueue(sse("research:error", { error: rawError }));
       } finally {
-        // Log to api_logs manually — logger.call can't wrap a live-streaming path
-        await prisma.apiLog.create({
-          data: {
-            competitorId: competitor.id,
-            endpoint: "research",
-            mode,
-            nocache: true,
-            status,
-            rawError: rawError ?? null,
-            durationMs: Date.now() - startTime,
-            resultQuality: status === "success" ? "full" : "empty",
-            isDemo: false
-          }
-        });
+        // Fail-open: log write must never prevent stream close
+        try {
+          await prisma.apiLog.create({
+            data: {
+              competitorId: competitor.id,
+              endpoint: "research",
+              mode,
+              nocache: true,
+              status,
+              rawError: rawError ?? null,
+              durationMs: Date.now() - startTime,
+              resultQuality: status === "success" ? "full" : "empty",
+              isDemo: false
+            }
+          });
+        } catch {
+          // api_log failure is non-fatal
+        }
         controller.close();
       }
     }

--- a/components/deep-dive/DeepDiveClient.tsx
+++ b/components/deep-dive/DeepDiveClient.tsx
@@ -54,6 +54,7 @@ export function DeepDiveClient({ competitorId, competitorName }: DeepDiveClientP
   const [completedTemplate, setCompletedTemplate] = useState<SelectedTemplate | null>(null);
 
   async function runDeepDive() {
+    if (isLoading) return;
     setEvents([]);
     setResult(null);
     setCitations([]);

--- a/components/deep-dive/DeepDiveClient.tsx
+++ b/components/deep-dive/DeepDiveClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { parseSseChunk } from "@/lib/utils/sse";
 import { DEEP_DIVE_TEMPLATES } from "@/lib/deep-dive-templates";
 import type { DeepDiveTemplateKey } from "@/lib/deep-dive-templates";
+import { RDSButton, RDSChip, RDSSectionHead } from "@/components/rds";
 
 type DeepDiveClientProps = {
   competitorId: string;
@@ -36,6 +37,10 @@ function getTemplateLabel(key: SelectedTemplate): string {
   if (key === "general") return GENERAL_TEMPLATE.label;
   const found = DEEP_DIVE_TEMPLATES.find((t) => t.key === key);
   return found?.label ?? "General Research";
+}
+
+function formatEventLabel(event: string): string {
+  return event.replace("research:", "").replace(/_/g, " ");
 }
 
 export function DeepDiveClient({ competitorId, competitorName }: DeepDiveClientProps) {
@@ -126,113 +131,271 @@ export function DeepDiveClient({ competitorId, competitorName }: DeepDiveClientP
     }
   }
 
-  return (
-    <div className="deep-dive-layout">
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Run Deep Dive</h2>
-        </header>
-        <p className="muted">{competitorName}</p>
+  const phaseEvents = events.filter(
+    (e) => e.event !== "research:started" && e.event !== "research:complete" && e.event !== "research:error"
+  );
 
-        <div className="template-selector">
-          <p className="template-selector-label">Research focus</p>
-          <div className="template-cards">
-            {ALL_TEMPLATES.map((template) => (
-              <label
-                key={template.key}
-                className={`template-card${selectedTemplate === template.key ? " template-card--selected" : ""}`}
-              >
-                <input
-                  type="radio"
-                  name="promptTemplate"
-                  value={template.key}
-                  checked={selectedTemplate === template.key}
-                  onChange={() => setSelectedTemplate(template.key as SelectedTemplate)}
-                  className="template-card-radio"
-                />
-                <strong className="template-card-title">{template.label}</strong>
-                <span className="template-card-desc">{template.description}</span>
-              </label>
-            ))}
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      {/* Controls */}
+      <div style={{ border: "1px solid var(--paper-rule)", padding: 20 }}>
+        <RDSSectionHead title="Run Deep Dive" level={2} />
+
+        <div style={{ marginBottom: 20 }}>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-10)",
+              letterSpacing: "var(--tr-kicker)",
+              textTransform: "uppercase",
+              color: "var(--ink-faint)",
+              marginBottom: 10
+            }}
+          >
+            Research focus
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 8 }}>
+            {ALL_TEMPLATES.map((template) => {
+              const selected = selectedTemplate === template.key;
+              return (
+                <label
+                  key={template.key}
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                    padding: "10px 12px",
+                    border: `1px solid ${selected ? "var(--ink)" : "var(--paper-rule)"}`,
+                    background: selected ? "var(--ink)" : "var(--paper)",
+                    cursor: "pointer"
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="promptTemplate"
+                    value={template.key}
+                    checked={selected}
+                    onChange={() => setSelectedTemplate(template.key as SelectedTemplate)}
+                    style={{ display: "none" }}
+                  />
+                  <span
+                    style={{
+                      fontFamily: "var(--font-sans)",
+                      fontSize: "var(--fs-13)",
+                      fontWeight: 600,
+                      color: selected ? "var(--ink-bg-text)" : "var(--ink)"
+                    }}
+                  >
+                    {template.label}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-11)",
+                      color: selected ? "var(--ink-bg-mute)" : "var(--ink-faint)",
+                      lineHeight: "var(--lh-body)"
+                    }}
+                  >
+                    {template.description}
+                  </span>
+                </label>
+              );
+            })}
           </div>
         </div>
 
-        <div className="mode-row">
-          <label>
-            <input type="radio" name="mode" checked={mode === "fast"} onChange={() => setMode("fast")} />
-            Fast
-          </label>
-          <label>
-            <input type="radio" name="mode" checked={mode === "balanced"} onChange={() => setMode("balanced")} />
-            Balanced
-          </label>
-          <button type="button" onClick={runDeepDive} disabled={isLoading}>
-            {isLoading ? "Running..." : "Start research"}
-          </button>
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-10)",
+              letterSpacing: "var(--tr-kicker)",
+              textTransform: "uppercase",
+              color: "var(--ink-faint)"
+            }}
+          >
+            Mode
+          </div>
+          {(["fast", "balanced"] as const).map((m) => (
+            <label key={m} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+              <input type="radio" name="mode" checked={mode === m} onChange={() => setMode(m)} />
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-12)",
+                  color: "var(--ink)"
+                }}
+              >
+                {m === "fast" ? "Fast (10–30s)" : "Balanced (1–2min)"}
+              </span>
+            </label>
+          ))}
+          <div style={{ marginLeft: "auto" }}>
+            <RDSButton variant="solid" size="md" onClick={runDeepDive} type="button">
+              {isLoading ? "Running…" : `Research ${competitorName}`}
+            </RDSButton>
+          </div>
         </div>
-        {error ? <p className="flag flag--error">{error}</p> : null}
-      </section>
 
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Live Research Stream</h2>
-        </header>
-        {events.length === 0 ? (
-          <p className="muted">No stream events yet.</p>
-        ) : (
-          <ul className="intel-feed">
-            {events.map((event) => (
-              <li key={event.id} className="intel-item">
-                <div className="intel-item-top">
-                  <strong>{event.event}</strong>
-                </div>
-                <pre className="json-view">{JSON.stringify(event.data, null, 2)}</pre>
-              </li>
+        {error && (
+          <div
+            style={{
+              marginTop: 12,
+              padding: "10px 12px",
+              border: "1px solid var(--accent-hot)",
+              color: "var(--accent-hot)",
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-12)"
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+
+      {(isLoading || phaseEvents.length > 0) && (
+        <div style={{ border: "1px solid var(--paper-rule)", padding: 20 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+            <RDSSectionHead title="Live Research Stream" level={2} />
+            {isLoading && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-10)",
+                  letterSpacing: "var(--tr-kicker)",
+                  textTransform: "uppercase",
+                  color: "var(--ok)"
+                }}
+              >
+                ● live
+              </span>
+            )}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {phaseEvents.map((event) => (
+              <div
+                key={event.id}
+                style={{
+                  display: "flex",
+                  gap: 12,
+                  padding: "6px 0",
+                  borderBottom: "1px solid var(--paper-rule)"
+                }}
+              >
+                <RDSChip style={{ flexShrink: 0 }}>{formatEventLabel(event.event)}</RDSChip>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-11)",
+                    color: "var(--ink-mute)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap"
+                  }}
+                >
+                  {typeof event.data === "object" ? JSON.stringify(event.data).slice(0, 120) : String(event.data ?? "")}
+                </span>
+              </div>
             ))}
-          </ul>
-        )}
-      </section>
+          </div>
+        </div>
+      )}
 
-      <section className="panel">
-        <header className="panel-header">
-          <h2>
-            Structured Report
-            {completedTemplate !== null ? (
-              <span className="template-badge">{getTemplateLabel(completedTemplate)}</span>
-            ) : null}
-          </h2>
-        </header>
-        {result ? (
-          <pre className="json-view">{JSON.stringify(result, null, 2)}</pre>
-        ) : (
-          <p className="muted">No report yet.</p>
-        )}
-      </section>
+      {/* Report */}
+      {result !== null && result !== undefined && (
+        <div style={{ border: "1px solid var(--paper-rule)", padding: 20 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+            <RDSSectionHead title="Structured Report" level={2} />
+            {completedTemplate && <RDSChip>{getTemplateLabel(completedTemplate)}</RDSChip>}
+          </div>
+          {typeof result === "string" ? (
+            <p
+              style={{
+                margin: 0,
+                fontFamily: "var(--font-serif)",
+                fontSize: "var(--fs-14)",
+                lineHeight: "var(--lh-body)",
+                color: "var(--ink)"
+              }}
+            >
+              {result}
+            </p>
+          ) : (
+            <pre
+              style={{
+                margin: 0,
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--fs-11)",
+                lineHeight: "var(--lh-body)",
+                color: "var(--ink)",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word"
+              }}
+            >
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
 
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Citations</h2>
-        </header>
-        {citations.length === 0 ? (
-          <p className="muted">No citations yet.</p>
-        ) : (
-          <ul className="citation-list">
+      {/* Citations */}
+      {citations.length > 0 && (
+        <div style={{ border: "1px solid var(--paper-rule)", padding: 20 }}>
+          <RDSSectionHead title="Citations" count={citations.length} level={2} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
             {citations.map((citation, index) => (
-              <li key={`${citation.source_url}-${index}`}>
-                <details>
-                  <summary>{citation.claim ?? `Citation ${index + 1}`}</summary>
-                  <p>
-                    <a href={citation.source_url} target="_blank" rel="noreferrer">
-                      {citation.source_url}
-                    </a>
-                  </p>
-                  {citation.source_text ? <p>{citation.source_text}</p> : null}
-                </details>
-              </li>
+              <details
+                key={`${citation.source_url}-${index}`}
+                style={{ borderBottom: "1px solid var(--paper-rule)", paddingBottom: 8 }}
+              >
+                <summary
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-12)",
+                    color: "var(--ink)",
+                    cursor: "pointer",
+                    listStyle: "none",
+                    display: "flex",
+                    gap: 8,
+                    alignItems: "flex-start"
+                  }}
+                >
+                  <span style={{ color: "var(--ink-faint)", flexShrink: 0 }}>{index + 1}.</span>
+                  <span>{citation.claim ?? citation.source_url}</span>
+                </summary>
+                <div style={{ marginTop: 8, paddingLeft: 20 }}>
+                  <a
+                    href={citation.source_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-11)",
+                      color: "var(--accent)",
+                      wordBreak: "break-all"
+                    }}
+                  >
+                    {citation.source_url}
+                  </a>
+                  {citation.source_text && (
+                    <p
+                      style={{
+                        margin: "6px 0 0",
+                        fontFamily: "var(--font-serif)",
+                        fontSize: "var(--fs-13)",
+                        color: "var(--ink-mute)",
+                        lineHeight: "var(--lh-body)"
+                      }}
+                    >
+                      {citation.source_text}
+                    </p>
+                  )}
+                </div>
+              </details>
             ))}
-          </ul>
-        )}
-      </section>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/tabstack/research.ts
+++ b/lib/tabstack/research.ts
@@ -79,7 +79,7 @@ export type ResearchInput = {
   fallback?: LoggerCallMetadata["fallback"];
 };
 
-function extractCitations(data: unknown): ResearchCitation[] {
+export function extractCitations(data: unknown): ResearchCitation[] {
   if (!isPlainObject(data)) {
     return [];
   }
@@ -119,7 +119,7 @@ function extractCitations(data: unknown): ResearchCitation[] {
   });
 }
 
-function extractResult(data: unknown): unknown {
+export function extractResult(data: unknown): unknown {
   if (!isPlainObject(data)) {
     return data ?? null;
   }


### PR DESCRIPTION
## What was broken

`/browserbase/deep-dive` (and all deep dive pages) didn't work because:

1. **Timeout** — `runResearch` buffered the entire research stream before returning. Netlify killed the connection after ~10s; balanced mode takes 1-2 minutes. Nothing ever reached the client.
2. **Async params** — Page used the old `params: { slug: string }` pattern; Next.js 15 requires `Promise<{ slug: string }>`.
3. **Old design** — Page and client still used raw classNames with no RDS.

## What changed

**`app/api/deep-dive/route.ts`** — Rewritten to stream directly from the Tabstack SDK. Each event is forwarded to the SSE response immediately as it arrives instead of waiting for full completion. `api_logs` entry written manually after stream closes (logger.call can't wrap a live-streaming path). `buildSelfContext` injection preserved for comparative framing.

**`lib/tabstack/research.ts`** — Exported `extractResult` and `extractCitations` so the route can use them without duplicating logic.

**`app/[slug]/deep-dive/page.tsx`** — Fixed async params, full RDS redesign (`RDSPageShell`, `RDSHeader`, `RDSKicker`, `RDSChip`, `RDSEmpty`, `RDSFooter`), back-link to competitor page.

**`components/deep-dive/DeepDiveClient.tsx`** — Full RDS redesign: card-style template selector, inline mode toggle, live event stream with chip labels, structured report, expandable citations.

**`app/api/__tests__/deep-dive.route.test.ts`** — Updated to mock `getTabstackClient` + async iterable stream instead of `runResearch`.

## Test Plan
- [ ] 406 tests pass
- [ ] Navigate to `/browserbase/deep-dive`, click Research — events stream live, report renders on completion
- [ ] Fast mode completes in ~30s, balanced in 1-2min without timeout
- [ ] `/insights` shows `research` endpoint after first run