### PR TITLE
feat(demo): multi-surface scan — 4 parallel pages + intelligence brief

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ SLACK_WEBHOOK_URL=
 # Config
 DEMO_RATE_LIMIT=3
 CRON_SECRET=
+# Local dev: skip DB writes for demo scanning (rate limit and lock not enforced)
+DEMO_SKIP_PERSISTENCE=
 INTERNAL_API_KEY=
 MANUAL_STALE_DAYS=30
 

--- a/app/api/__tests__/demo.route.test.ts
+++ b/app/api/__tests__/demo.route.test.ts
@@ -9,7 +9,8 @@ const {
   demoIpLockCreateMock,
   demoIpLockDeleteMock,
   demoScanCountMock,
-  demoScanCreateMock
+  demoScanCreateMock,
+  generateDemoBriefMock
 } = vi.hoisted(() => ({
   scanPageMock: vi.fn(),
   inferBlogPageTypeMock: vi.fn(),
@@ -17,7 +18,8 @@ const {
   demoIpLockCreateMock: vi.fn(),
   demoIpLockDeleteMock: vi.fn(),
   demoScanCountMock: vi.fn(),
-  demoScanCreateMock: vi.fn()
+  demoScanCreateMock: vi.fn(),
+  generateDemoBriefMock: vi.fn()
 }));
 
 vi.mock("@/lib/scanner", () => ({
@@ -25,6 +27,7 @@ vi.mock("@/lib/scanner", () => ({
   inferBlogPageType: inferBlogPageTypeMock,
   inferPageTypeFromUrl: inferPageTypeFromUrlMock
 }));
+vi.mock("@/lib/tabstack/generate", () => ({ generateDemoBrief: generateDemoBriefMock }));
 vi.mock("@/lib/db/client", () => ({
   prisma: {
     demoIpLock: {
@@ -100,6 +103,7 @@ describe("POST /api/demo", () => {
     demoIpLockDeleteMock.mockReset();
     demoScanCountMock.mockReset();
     demoScanCreateMock.mockReset();
+    generateDemoBriefMock.mockReset();
 
     // Default: lock acquired, within daily limit, scan succeeds
     demoIpLockCreateMock.mockResolvedValue({ ipHash: "abc" });
@@ -109,6 +113,9 @@ describe("POST /api/demo", () => {
     scanPageMock.mockResolvedValue(SCAN_RESULT);
     inferBlogPageTypeMock.mockReturnValue(null);
     inferPageTypeFromUrlMock.mockReturnValue(null);
+    generateDemoBriefMock.mockResolvedValue({
+      data: { positioning_signal: "pos", opportunity: "opp", watch_signal: "watch" }
+    });
   });
 
   it("returns 429 when a concurrent lock is held", async () => {
@@ -240,7 +247,7 @@ describe("POST /api/demo", () => {
 
   it("scan:complete event contains scan result fields", async () => {
     const { POST } = await import("@/app/api/demo/route");
-    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     const events = await drainStream(getBody(res));
 
     const complete = events.find((e) => e.event === "scan:complete");
@@ -252,7 +259,7 @@ describe("POST /api/demo", () => {
 
   it("creates a demoScan record after a successful scan", async () => {
     const { POST } = await import("@/app/api/demo/route");
-    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     await drainStream(getBody(res));
 
     expect(demoScanCreateMock).toHaveBeenCalledOnce();
@@ -260,7 +267,7 @@ describe("POST /api/demo", () => {
 
   it("releases the lock after stream completes successfully", async () => {
     const { POST } = await import("@/app/api/demo/route");
-    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     await drainStream(getBody(res));
 
     expect(demoIpLockDeleteMock).toHaveBeenCalled();
@@ -270,7 +277,7 @@ describe("POST /api/demo", () => {
     scanPageMock.mockRejectedValueOnce(new Error("Scan failed hard"));
 
     const { POST } = await import("@/app/api/demo/route");
-    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     const events = await drainStream(getBody(res));
 
     const errorEvent = events.find((e) => e.event === "scan:error");
@@ -283,7 +290,7 @@ describe("POST /api/demo", () => {
     scanPageMock.mockRejectedValueOnce("string rejection");
 
     const { POST } = await import("@/app/api/demo/route");
-    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
     const events = await drainStream(getBody(res));
 
     const errorEvent = events.find((e) => e.event === "scan:error");
@@ -362,5 +369,154 @@ describe("POST /api/demo", () => {
     await drainStream(getBody(res));
 
     expect(scanPageMock).toHaveBeenCalledWith(expect.objectContaining({ type: "pricing", customTask: undefined }));
+  });
+
+  describe("multi-surface scan (root URL)", () => {
+    it("emits scan:surfaces with 4 pages for a root URL", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const surfacesEvent = events.find((e) => e.event === "scan:surfaces");
+      expect(surfacesEvent).toBeDefined();
+      const pages = (surfacesEvent?.data as { pages: Array<{ type: string; url: string }> }).pages;
+      expect(pages.map((p) => p.type)).toEqual(["homepage", "pricing", "blog", "careers"]);
+      expect(pages.find((p) => p.type === "homepage")?.url).toBe("https://example.com/");
+      expect(pages.find((p) => p.type === "pricing")?.url).toBe("https://example.com/pricing");
+      expect(pages.find((p) => p.type === "blog")?.url).toBe("https://example.com/blog");
+      expect(pages.find((p) => p.type === "careers")?.url).toBe("https://example.com/careers");
+    });
+
+    it("calls scanPage 4 times with effortOverride: low and isDemo: true", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      await drainStream(getBody(res));
+
+      expect(scanPageMock).toHaveBeenCalledTimes(4);
+      for (const call of scanPageMock.mock.calls) {
+        expect(call[0]).toMatchObject({ effortOverride: "low", isDemo: true });
+      }
+    });
+
+    it("emits scan:page_complete for each non-empty surface result", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const pageCompletes = events.filter((e) => e.event === "scan:page_complete");
+      expect(pageCompletes.length).toBe(4);
+      const types = pageCompletes.map((e) => (e.data as { type: string }).type);
+      expect(types).toContain("homepage");
+      expect(types).toContain("pricing");
+    });
+
+    it("scan:page_complete carries type, url, result, endpointUsed, usedFallback", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const homepageComplete = events.find(
+        (e) => e.event === "scan:page_complete" && (e.data as { type: string }).type === "homepage"
+      );
+      expect(homepageComplete?.data).toMatchObject({
+        type: "homepage",
+        url: "https://example.com/",
+        result: SCAN_RESULT.rawResult,
+        endpointUsed: "extract/json",
+        usedFallback: false
+      });
+    });
+
+    it("emits scan:brief_started then scan:brief_complete after page results", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const names = events.map((e) => e.event);
+      expect(names).toContain("scan:brief_started");
+      expect(names).toContain("scan:brief_complete");
+      const briefIdx = names.indexOf("scan:brief_started");
+      const lastPageIdx = names.lastIndexOf("scan:page_complete");
+      expect(briefIdx).toBeGreaterThan(lastPageIdx);
+    });
+
+    it("scan:brief_complete contains positioning_signal, opportunity, watch_signal", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const briefEvent = events.find((e) => e.event === "scan:brief_complete");
+      expect(briefEvent?.data).toMatchObject({
+        positioning_signal: "pos",
+        opportunity: "opp",
+        watch_signal: "watch"
+      });
+    });
+
+    it("creates exactly 1 demoScan record regardless of surface count", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      await drainStream(getBody(res));
+
+      expect(demoScanCreateMock).toHaveBeenCalledOnce();
+    });
+
+    it("silently drops surfaces with empty rawResult — no scan:page_complete for them", async () => {
+      scanPageMock
+        .mockResolvedValueOnce(SCAN_RESULT)
+        .mockResolvedValueOnce({ ...SCAN_RESULT, rawResult: null })
+        .mockResolvedValueOnce(SCAN_RESULT)
+        .mockResolvedValueOnce(SCAN_RESULT);
+
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      const pageCompletes = events.filter((e) => e.event === "scan:page_complete");
+      expect(pageCompletes.length).toBe(3);
+      const types = pageCompletes.map((e) => (e.data as { type: string }).type);
+      expect(types).not.toContain("pricing");
+    });
+
+    it("omits brief when all surfaces return empty", async () => {
+      scanPageMock.mockResolvedValue({ ...SCAN_RESULT, rawResult: null });
+
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      expect(events.find((e) => e.event === "scan:brief_started")).toBeUndefined();
+      expect(events.find((e) => e.event === "scan:brief_complete")).toBeUndefined();
+    });
+
+    it("omits brief silently when generateDemoBrief throws", async () => {
+      generateDemoBriefMock.mockRejectedValueOnce(new Error("Generate failed"));
+
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      expect(events.filter((e) => e.event === "scan:page_complete").length).toBe(4);
+      expect(events.find((e) => e.event === "scan:error")).toBeUndefined();
+    });
+
+    it("does not trigger multi-surface for a non-root URL", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+      const events = await drainStream(getBody(res));
+
+      expect(events.find((e) => e.event === "scan:surfaces")).toBeUndefined();
+      expect(scanPageMock).toHaveBeenCalledOnce();
+      expect(events.find((e) => e.event === "scan:complete")).toBeDefined();
+    });
+
+    it("does not emit scan:endpoint or scan:complete for a root URL (multi-surface path)", async () => {
+      const { POST } = await import("@/app/api/demo/route");
+      const res = await POST(makeRequest({ url: "https://example.com" }));
+      const events = await drainStream(getBody(res));
+
+      expect(events.find((e) => e.event === "scan:endpoint")).toBeUndefined();
+      expect(events.find((e) => e.event === "scan:complete")).toBeUndefined();
+    });
   });
 });

--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -4,10 +4,35 @@ import { Prisma } from "@prisma/client";
 import type { NextRequest } from "next/server";
 
 import { prisma } from "@/lib/db/client";
+import { generateDemoBrief } from "@/lib/tabstack/generate";
 import { inferBlogPageType, scanPage } from "@/lib/scanner";
+import { isPlainObject } from "@/lib/utils/types";
 
 const MAX_SCANS_PER_DAY = 3;
+const SCAN_TIMEOUT_MS = 22_000;
+const PER_PAGE_TIMEOUT_MS = 15_000;
+const BRIEF_TIMEOUT_MS = 5_000;
 const encoder = new TextEncoder();
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("scan_timeout")), ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err: unknown) => { clearTimeout(timer); reject(err); }
+    );
+  });
+}
+
+function buildSurfaces(parsedUrl: URL): Array<{ type: string; url: string }> {
+  const base = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+  return [
+    { type: "homepage", url: parsedUrl.toString() },
+    { type: "pricing", url: `${base}/pricing` },
+    { type: "blog", url: `${base}/blog` },
+    { type: "careers", url: `${base}/careers` }
+  ];
+}
 
 function sse(event: string, data: unknown): Uint8Array {
   return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -19,6 +44,13 @@ function ipHash(ip: string): string {
 
 function inferPageType(rawUrl: string): string {
   const lower = rawUrl.toLowerCase();
+  // Root URL — no meaningful path segment → treat as homepage for multi-surface scan.
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.pathname === "/" || parsed.pathname === "") return "homepage";
+  } catch {
+    // Malformed URLs are caught upstream; continue to keyword matching as fallback.
+  }
   // Review platforms first so keyword collisions (e.g. "pricing") do not misclassify.
   if (
     lower.includes("g2.com") ||
@@ -83,6 +115,35 @@ function isPrivateHost(hostname: string): boolean {
     if (segment >= 16 && segment <= 31) return true;
   }
   return false;
+}
+
+function demoResultIsEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (isPlainObject(v) && Object.keys(v as Record<string, unknown>).length === 0) return true;
+  return false;
+}
+
+function extractDemoBriefData(
+  raw: unknown
+): { positioning_signal: string; opportunity: string; watch_signal: string } | null {
+  const payload =
+    isPlainObject(raw) && "data" in (raw as Record<string, unknown>)
+      ? (raw as Record<string, unknown>).data
+      : raw;
+  if (!isPlainObject(payload)) return null;
+  const d = payload as Record<string, unknown>;
+  if (
+    typeof d.positioning_signal === "string" &&
+    typeof d.opportunity === "string" &&
+    typeof d.watch_signal === "string"
+  ) {
+    return {
+      positioning_signal: d.positioning_signal,
+      opportunity: d.opportunity,
+      watch_signal: d.watch_signal
+    };
+  }
+  return null;
 }
 
 // Attempt to acquire a per-IP lock using a unique-key INSERT.
@@ -176,40 +237,112 @@ export async function POST(request: NextRequest) {
     }
 
     const type = inferPageType(parsedUrl.toString());
+    const isLocal = process.env.DEMO_SKIP_PERSISTENCE === "true";
     lockOwnedByStream = true;
 
     const stream = new ReadableStream({
       start: async (controller) => {
         try {
           controller.enqueue(sse("scan:started", { url: parsedUrl.toString() }));
-          controller.enqueue(sse("scan:endpoint", { type }));
 
-          const result = await scanPage({
-            url: parsedUrl.toString(),
-            type,
-            isDemo: true,
-            customTask: type === "custom" ? "Extract high-signal competitive intelligence from this page." : undefined
-          });
+          if (type === "homepage") {
+            // ── Multi-surface path ────────────────────────────────────────────
+            const surfaces = buildSurfaces(parsedUrl);
+            controller.enqueue(sse("scan:surfaces", { pages: surfaces }));
 
-          await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+            const outcomes = await withTimeout(
+              Promise.allSettled(
+                surfaces.map(({ type: surfaceType, url: surfaceUrl }) =>
+                  withTimeout(
+                    scanPage({ url: surfaceUrl, type: surfaceType, isDemo: true, effortOverride: "low" }),
+                    PER_PAGE_TIMEOUT_MS
+                  ).then((result) => ({ type: surfaceType, url: surfaceUrl, result }))
+                )
+              ),
+              SCAN_TIMEOUT_MS
+            );
 
-          controller.enqueue(
-            sse("scan:complete", {
-              endpointUsed: result.endpointUsed,
-              usedFallback: result.usedFallback,
-              diffSummary: result.diffSummary,
-              hasChanges: result.hasChanges,
-              result: result.rawResult
-            })
-          );
+            const successfulResults: Array<{ type: string; result: unknown }> = [];
+
+            for (const outcome of outcomes) {
+              if (outcome.status === "rejected") continue;
+              const { type: surfaceType, url: surfaceUrl, result } = outcome.value;
+              if (demoResultIsEmpty(result.rawResult)) continue;
+              controller.enqueue(
+                sse("scan:page_complete", {
+                  type: surfaceType,
+                  url: surfaceUrl,
+                  result: result.rawResult,
+                  endpointUsed: result.endpointUsed,
+                  usedFallback: result.usedFallback
+                })
+              );
+              successfulResults.push({ type: surfaceType, result: result.rawResult });
+            }
+
+            if (successfulResults.length > 0) {
+              controller.enqueue(sse("scan:brief_started", {}));
+              try {
+                const contextData = JSON.stringify(
+                  successfulResults.reduce<Record<string, unknown>>((acc, { type: t, result: r }) => {
+                    acc[t] = r;
+                    return acc;
+                  }, {})
+                );
+                const briefRaw = await withTimeout(
+                  generateDemoBrief({ url: parsedUrl.toString(), contextData, isDemo: true }),
+                  BRIEF_TIMEOUT_MS
+                );
+                const brief = extractDemoBriefData(briefRaw);
+                if (brief) controller.enqueue(sse("scan:brief_complete", brief));
+              } catch {
+                // Brief is a bonus — silently omit on failure or timeout
+              }
+            }
+
+            if (!isLocal) await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+          } else {
+            // ── Single-page path (unchanged) ─────────────────────────────────
+            controller.enqueue(sse("scan:endpoint", { type }));
+
+            const result = await withTimeout(
+              scanPage({
+                url: parsedUrl.toString(),
+                type,
+                isDemo: true,
+                customTask: type === "custom" ? "Extract high-signal competitive intelligence from this page." : undefined
+              }),
+              SCAN_TIMEOUT_MS
+            );
+
+            if (!isLocal) await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+
+            controller.enqueue(
+              sse("scan:complete", {
+                endpointUsed: result.endpointUsed,
+                usedFallback: result.usedFallback,
+                diffSummary: result.diffSummary,
+                hasChanges: result.hasChanges,
+                result: result.rawResult
+              })
+            );
+          }
         } catch (error) {
-          controller.enqueue(
-            sse("scan:error", {
-              error: error instanceof Error ? error.message : "Demo scan failed"
-            })
-          );
+          if (error instanceof Error && error.message === "scan_timeout") {
+            controller.enqueue(
+              sse("scan:timeout", {
+                message: "Scan exceeded the 22s limit — try a simpler page type (homepage, blog, docs) for faster results."
+              })
+            );
+          } else {
+            controller.enqueue(
+              sse("scan:error", {
+                error: error instanceof Error ? error.message : "Demo scan failed"
+              })
+            );
+          }
         } finally {
-          await releaseLock(hashedIp);
+          if (!isLocal) await releaseLock(hashedIp);
           controller.close();
         }
       },

--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -66,16 +66,6 @@ function inferPageType(rawUrl: string): string {
   if (lower.includes("docs")) return "docs";
   if (lower.includes("github.com")) return "github";
   if (inferBlogPageType(rawUrl)) return "blog";
-  // Review platforms — content_blocked is expected and the most valuable
-  // experience-logging signal in the codebase. Infer before generic checks.
-  if (
-    lower.includes("g2.com") ||
-    lower.includes("capterra.com") ||
-    lower.includes("trustpilot.com") ||
-    lower.includes("producthunt.com")
-  ) {
-    return "reviews";
-  }
   if (
     lower.includes("linkedin.com") ||
     lower.includes("twitter.com") ||
@@ -347,7 +337,7 @@ export async function POST(request: NextRequest) {
         }
       },
       cancel() {
-        void releaseLock(hashedIp);
+        if (!isLocal) void releaseLock(hashedIp);
       }
     });
 

--- a/components/demo/DemoClient.tsx
+++ b/components/demo/DemoClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { parseSseChunk } from "@/lib/utils/sse";
+import { RDSChip, RDSSectionHead } from "@/components/rds";
 
 type DemoEvent = {
   id: string;
@@ -9,16 +10,509 @@ type DemoEvent = {
   data: unknown;
 };
 
+type ScanCompleteData = {
+  endpointUsed: string;
+  usedFallback: boolean;
+  diffSummary: string | null;
+  hasChanges: boolean;
+  result: unknown;
+};
+
+type ScanSurfaces = {
+  pages: Array<{ type: string; url: string }>;
+};
+
+type PageCompleteData = {
+  type: string;
+  url: string;
+  result: unknown;
+  endpointUsed: string;
+  usedFallback: boolean;
+};
+
+type BriefData = {
+  positioning_signal: string;
+  opportunity: string;
+  watch_signal: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function ResultValue({ value }: { value: unknown }): React.ReactNode {
+  if (value === null || value === undefined) {
+    return <span style={{ color: "var(--ink-faint)", fontStyle: "italic" }}>—</span>;
+  }
+  if (typeof value === "boolean") {
+    return (
+      <span style={{ color: value ? "var(--ok)" : "var(--accent-hot)" }}>{value ? "Yes" : "No"}</span>
+    );
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span style={{ color: "var(--ink-faint)", fontStyle: "italic" }}>empty</span>;
+    }
+    return (
+      <ul style={{ margin: 0, paddingLeft: 16, listStyle: "disc" }}>
+        {value.map((item, i) => (
+          <li key={i} style={{ marginBottom: 2 }}>
+            <ResultValue value={item} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  if (isObject(value)) {
+    return <ResultObject obj={value} />;
+  }
+  return <span>{String(value)}</span>;
+}
+
+function ResultObject({ obj }: { obj: Record<string, unknown> }): React.ReactNode {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {Object.entries(obj).map(([key, val]) => (
+        <div key={key} style={{ display: "flex", gap: 8 }}>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: "var(--ink-faint)",
+              flexShrink: 0,
+              paddingTop: 2
+            }}
+          >
+            {key.replace(/_/g, " ")}:
+          </span>
+          <ResultValue value={val} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ScanResult({ data }: { data: ScanCompleteData }) {
+  const result = data.result;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <RDSChip tone="solid">{data.endpointUsed}</RDSChip>
+        {data.usedFallback && <RDSChip tone="hot">Fallback triggered</RDSChip>}
+        {data.hasChanges && <RDSChip tone="ok">Changes detected</RDSChip>}
+      </div>
+      {isObject(result) && Object.keys(result).length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+          {Object.entries(result).map(([key, value]) => {
+            const isEmpty =
+              value === null ||
+              value === undefined ||
+              (Array.isArray(value) && value.length === 0) ||
+              (typeof value === "string" && value.trim().length === 0) ||
+              (typeof value === "number" && value === 0);
+            return (
+              <div
+                key={key}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "200px 1fr",
+                  gap: 16,
+                  padding: "10px 0",
+                  borderBottom: "1px dotted var(--paper-rule-2)",
+                  alignItems: "start",
+                  opacity: isEmpty ? 0.45 : 1
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    letterSpacing: "0.1em",
+                    color: "var(--ink-faint)",
+                    textTransform: "uppercase",
+                    paddingTop: 3
+                  }}
+                >
+                  {key.replace(/_/g, " ")}
+                </div>
+                <div style={{ fontSize: 14, lineHeight: 1.5, color: "var(--ink)" }}>
+                  <ResultValue value={value} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p style={{ color: "var(--ink-faint)", fontStyle: "italic", fontSize: 14, margin: 0 }}>
+          No data extracted — page may have blocked the scan.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ProgressLog({
+  events,
+  isRunning
+}: {
+  events: DemoEvent[];
+  isRunning: boolean;
+}) {
+  const labels: Record<string, string> = {
+    "scan:started": "Scan started",
+    "scan:endpoint": "Endpoint selected",
+    "scan:complete": "Scan complete",
+    "scan:error": "Error",
+    "scan:timeout": "Timed out"
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+      {events.map((e) => {
+        const label = labels[e.event] ?? e.event;
+        const isError = e.event === "scan:error" || e.event === "scan:timeout";
+        const isComplete = e.event === "scan:complete";
+        const color = isError
+          ? "var(--accent-hot)"
+          : isComplete
+            ? "var(--ok)"
+            : "var(--ink)";
+        return (
+          <div
+            key={e.id}
+            style={{
+              display: "flex",
+              gap: 14,
+              padding: "10px 0",
+              borderBottom: "1px dotted var(--paper-rule-2)"
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 13,
+                color,
+                width: 16,
+                flexShrink: 0
+              }}
+            >
+              {isError ? "✗" : isComplete ? "✓" : "→"}
+            </span>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>{label}</div>
+              {e.event === "scan:started" && isObject(e.data) && typeof e.data.url === "string" && (
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    color: "var(--ink-faint)",
+                    marginTop: 2,
+                    wordBreak: "break-all"
+                  }}
+                >
+                  {e.data.url}
+                </div>
+              )}
+              {e.event === "scan:endpoint" && isObject(e.data) && typeof e.data.type === "string" && (
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    color: "var(--ink-faint)",
+                    marginTop: 2
+                  }}
+                >
+                  {e.data.type}
+                </div>
+              )}
+              {isError && isObject(e.data) && (
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    color: "var(--accent-hot)",
+                    marginTop: 2
+                  }}
+                >
+                  {typeof e.data.error === "string"
+                    ? e.data.error
+                    : typeof e.data.message === "string"
+                      ? e.data.message
+                      : ""}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+      {isRunning && (
+        <div
+          style={{
+            display: "flex",
+            gap: 14,
+            padding: "10px 0"
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 13,
+              color: "var(--accent)",
+              width: 16,
+              flexShrink: 0
+            }}
+          >
+            ·
+          </span>
+          <div style={{ fontSize: 14, color: "var(--ink-faint)", fontStyle: "italic" }}>
+            Scanning…
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MultiSurfaceProgressLog({
+  surfaces,
+  pageResults,
+  briefPending,
+  brief,
+  isRunning,
+  startedUrl
+}: {
+  surfaces: Array<{ type: string; url: string }>;
+  pageResults: PageCompleteData[];
+  briefPending: boolean;
+  brief: BriefData | null;
+  isRunning: boolean;
+  startedUrl: string;
+}) {
+  const completedTypes = new Set(pageResults.map((r) => r.type));
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+      <ProgressRow symbol="✓" tone="ok" label="Scan started" detail={startedUrl} done />
+      <ProgressRow
+        symbol="✓"
+        tone="ok"
+        label={`Scanning ${surfaces.length} surfaces`}
+        detail={surfaces.map((s) => s.type).join(" · ")}
+        done
+      />
+      {surfaces.map(({ type }) => {
+        const done = completedTypes.has(type);
+        const running = isRunning && !done;
+        return (
+          <ProgressRow
+            key={type}
+            symbol={done ? "✓" : running ? "→" : "·"}
+            tone={done ? "ok" : running ? "accent" : "faint"}
+            label={done ? `${type} — extracted` : running ? `${type} — extracting…` : type}
+            detail=""
+            done={done}
+          />
+        );
+      })}
+      {(briefPending || brief) && (
+        <ProgressRow
+          symbol={brief ? "✓" : "→"}
+          tone={brief ? "ok" : "accent"}
+          label={brief ? "Intelligence brief — complete" : "Synthesizing brief…"}
+          detail=""
+          done={Boolean(brief)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ProgressRow({
+  symbol,
+  tone,
+  label,
+  detail,
+  done
+}: {
+  symbol: string;
+  tone: "ok" | "accent" | "faint";
+  label: string;
+  detail: string;
+  done: boolean;
+}) {
+  const color =
+    tone === "ok" ? "var(--ok)" : tone === "accent" ? "var(--accent)" : "var(--ink-faint)";
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 14,
+        padding: "10px 0",
+        borderBottom: "1px dotted var(--paper-rule-2)",
+        opacity: done || tone === "accent" ? 1 : 0.35
+      }}
+    >
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: 13, color, width: 16, flexShrink: 0 }}>
+        {symbol}
+      </span>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>{label}</div>
+        {detail && (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--ink-faint)",
+              marginTop: 2,
+              wordBreak: "break-all"
+            }}
+          >
+            {detail}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MultiSurfaceResults({ pageResults }: { pageResults: PageCompleteData[] }) {
+  if (pageResults.length === 0) return null;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+      {pageResults.map((page) => (
+        <div key={page.type}>
+          <div style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
+            <RDSChip tone="solid">{page.type}</RDSChip>
+            <RDSChip tone="solid">{page.endpointUsed}</RDSChip>
+            {page.usedFallback && <RDSChip tone="hot">Fallback triggered</RDSChip>}
+          </div>
+          {isObject(page.result) && Object.keys(page.result).length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+              {Object.entries(page.result as Record<string, unknown>).map(([key, value]) => {
+                const isEmpty =
+                  value === null ||
+                  value === undefined ||
+                  (Array.isArray(value) && value.length === 0) ||
+                  (typeof value === "string" && value.trim().length === 0) ||
+                  (typeof value === "number" && value === 0);
+                return (
+                  <div
+                    key={key}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "200px 1fr",
+                      gap: 16,
+                      padding: "10px 0",
+                      borderBottom: "1px dotted var(--paper-rule-2)",
+                      alignItems: "start",
+                      opacity: isEmpty ? 0.45 : 1
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        letterSpacing: "0.1em",
+                        color: "var(--ink-faint)",
+                        textTransform: "uppercase",
+                        paddingTop: 3
+                      }}
+                    >
+                      {key.replace(/_/g, " ")}
+                    </div>
+                    <div style={{ fontSize: 14, lineHeight: 1.5, color: "var(--ink)" }}>
+                      <ResultValue value={value} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p style={{ color: "var(--ink-faint)", fontStyle: "italic", fontSize: 14, margin: 0 }}>
+              No data extracted — page may have blocked the scan.
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BriefSection({ brief }: { brief: BriefData }) {
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "POSITIONING SIGNAL", value: brief.positioning_signal },
+    { label: "OPPORTUNITY", value: brief.opportunity },
+    { label: "WATCH", value: brief.watch_signal }
+  ];
+  return (
+    <div
+      style={{
+        marginTop: 32,
+        padding: "20px 24px",
+        background: "var(--ink)",
+        color: "var(--ink-bg-text)"
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.18em",
+          color: "var(--ink-ghost)",
+          marginBottom: 16
+        }}
+      >
+        INTELLIGENCE BRIEF
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        {rows.map(({ label, value }) => (
+          <div
+            key={label}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "200px 1fr",
+              gap: 16,
+              padding: "12px 0",
+              borderTop: "1px solid var(--ink-2)"
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                color: "var(--ink-ghost)",
+                paddingTop: 2
+              }}
+            >
+              {label}
+            </div>
+            <div style={{ fontSize: 14, lineHeight: 1.55, textWrap: "pretty" }}>{value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function DemoClient() {
   const [url, setUrl] = useState("");
   const [events, setEvents] = useState<DemoEvent[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [surfaces, setSurfaces] = useState<Array<{ type: string; url: string }>>([]);
+  const [pageResults, setPageResults] = useState<PageCompleteData[]>([]);
+  const [brief, setBrief] = useState<BriefData | null>(null);
+  const [briefPending, setBriefPending] = useState(false);
 
   async function runDemo() {
     setEvents([]);
     setError(null);
     setIsRunning(true);
+    setSurfaces([]);
+    setPageResults([]);
+    setBrief(null);
+    setBriefPending(false);
 
     try {
       const response = await fetch("/api/demo", {
@@ -58,6 +552,19 @@ export function DemoClient() {
             const payload = event.data as { error?: string };
             setError(payload?.error ?? "Demo scan failed");
           }
+          if (event.event === "scan:surfaces") {
+            setSurfaces((event.data as ScanSurfaces).pages);
+          }
+          if (event.event === "scan:page_complete") {
+            setPageResults((prev) => [...prev, event.data as PageCompleteData]);
+          }
+          if (event.event === "scan:brief_started") {
+            setBriefPending(true);
+          }
+          if (event.event === "scan:brief_complete") {
+            setBrief(event.data as BriefData);
+            setBriefPending(false);
+          }
         }
       }
 
@@ -71,6 +578,19 @@ export function DemoClient() {
             const payload = event.data as { error?: string };
             setError(payload?.error ?? "Demo scan failed");
           }
+          if (event.event === "scan:surfaces") {
+            setSurfaces((event.data as ScanSurfaces).pages);
+          }
+          if (event.event === "scan:page_complete") {
+            setPageResults((prev) => [...prev, event.data as PageCompleteData]);
+          }
+          if (event.event === "scan:brief_started") {
+            setBriefPending(true);
+          }
+          if (event.event === "scan:brief_complete") {
+            setBrief(event.data as BriefData);
+            setBriefPending(false);
+          }
         }
       }
     } catch (error) {
@@ -80,47 +600,107 @@ export function DemoClient() {
     }
   }
 
+  const completeEvent = events.find((e) => e.event === "scan:complete");
+  const isMultiSurface = surfaces.length > 0;
+  const hasResult = isMultiSurface ? pageResults.length > 0 || briefPending : Boolean(completeEvent);
+
   return (
-    <div className="deep-dive-layout">
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Run Public Demo Scan</h2>
-        </header>
-        <div className="filters">
-          <label>
-            URL
-            <input
-              value={url}
-              onChange={(event) => setUrl(event.target.value)}
-              placeholder="https://example.com/pricing"
-            />
-          </label>
-          <button type="button" onClick={runDemo} disabled={isRunning || !url.trim()}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: 14, fontWeight: 600 }}>
+          URL
+          <input
+            value={url}
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder="https://example.com/pricing"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 13,
+              padding: "8px 12px",
+              border: "1px solid var(--ink)",
+              background: "var(--paper)",
+              color: "var(--ink)",
+              width: "100%",
+              maxWidth: 480
+            }}
+          />
+        </label>
+        <div>
+          <button
+            type="button"
+            onClick={runDemo}
+            disabled={isRunning || !url.trim()}
+            style={{
+              fontFamily: "var(--font-sans)",
+              fontWeight: 600,
+              fontSize: 13,
+              padding: "10px 14px",
+              background: isRunning || !url.trim() ? "var(--paper-edge)" : "var(--ink)",
+              color: isRunning || !url.trim() ? "var(--ink-faint)" : "var(--ink-bg-text)",
+              border: "1px solid var(--ink)",
+              cursor: isRunning || !url.trim() ? "not-allowed" : "pointer"
+            }}
+          >
             {isRunning ? "Scanning..." : "Run demo"}
           </button>
         </div>
-        {error ? <p className="flag flag--error">{error}</p> : null}
-      </section>
+        {error ? (
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13,
+              color: "var(--accent-hot)",
+              fontFamily: "var(--font-mono)"
+            }}
+          >
+            {error}
+          </p>
+        ) : null}
+      </div>
 
-      <section className="panel">
-        <header className="panel-header">
-          <h2>Live Progress</h2>
-        </header>
-        {events.length === 0 ? (
-          <p className="muted">No events yet.</p>
-        ) : (
-          <ul className="intel-feed">
-            {events.map((event) => (
-              <li key={event.id} className="intel-item">
-                <div className="intel-item-top">
-                  <strong>{event.event}</strong>
-                </div>
-                <pre className="json-view">{JSON.stringify(event.data, null, 2)}</pre>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      {events.length > 0 && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              (isMultiSurface && hasResult) || (!isMultiSurface && hasResult) ? "1fr 2fr" : "1fr",
+            gap: 32
+          }}
+        >
+          <div>
+            <RDSSectionHead title="Progress" level={3} />
+            {isMultiSurface ? (
+              <MultiSurfaceProgressLog
+                surfaces={surfaces}
+                pageResults={pageResults}
+                briefPending={briefPending}
+                brief={brief}
+                isRunning={isRunning}
+                startedUrl={
+                  (events.find((e) => e.event === "scan:started")?.data as { url?: string })?.url ?? ""
+                }
+              />
+            ) : (
+              <ProgressLog events={events} isRunning={isRunning} />
+            )}
+          </div>
+
+          {isMultiSurface && (pageResults.length > 0 || brief) && (
+            <div>
+              <RDSSectionHead title="Extracted Data" level={3} />
+              <MultiSurfaceResults pageResults={pageResults} />
+              {brief && <BriefSection brief={brief} />}
+            </div>
+          )}
+
+          {!isMultiSurface && hasResult && completeEvent && (
+            <div>
+              <RDSSectionHead title="Extracted Data" level={3} />
+              <ScanResult data={completeEvent.data as ScanCompleteData} />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/__tests__/scanner.test.ts
+++ b/lib/__tests__/scanner.test.ts
@@ -354,6 +354,22 @@ describe("scanPage", () => {
     expect(automateExtractMock).not.toHaveBeenCalled();
   });
 
+  it("uses effortOverride when provided, ignoring the per-type routing effort", async () => {
+    const { scanPage } = await import("@/lib/scanner");
+
+    await scanPage({
+      competitorId: "cmp_1",
+      pageId: "page_1",
+      url: "https://example.com/pricing",
+      type: "pricing",
+      effortOverride: "low" // pricing normally routes to effort: "high"
+    });
+
+    expect(extractJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ effort: "low" })
+    );
+  });
+
   it("uses automate fallback for blog when extract/json is empty", async () => {
     extractJsonMock.mockResolvedValueOnce({ data: {} });
     extractMarkdownMock.mockResolvedValueOnce({

--- a/lib/scanner.ts
+++ b/lib/scanner.ts
@@ -468,7 +468,7 @@ async function runPrimaryScan(input: ScanPageInput): Promise<{
       competitorId: input.competitorId,
       pageId: input.pageId,
       url: input.url,
-      effort: input.effortOverride ?? "low",
+      effort: input.effortOverride ?? route.effort ?? "low",
       nocache,
       geoTarget: input.geoTarget,
       isDemo: input.isDemo,

--- a/lib/scanner.ts
+++ b/lib/scanner.ts
@@ -171,6 +171,7 @@ export type ScanPageInput = {
   nocache?: boolean;
   isDemo?: boolean;
   customTask?: string;
+  effortOverride?: TabstackEffort; // forces effort on all Tabstack calls — used by demo mode
 };
 
 export type ScanPageOutput = {
@@ -381,7 +382,7 @@ async function runPrimaryScan(input: ScanPageInput): Promise<{
       competitorId: input.competitorId,
       pageId: input.pageId,
       url: input.url,
-      effort: route.effort ?? "low",
+      effort: input.effortOverride ?? route.effort ?? "low",
       nocache,
       geoTarget: input.geoTarget,
       isDemo: input.isDemo
@@ -421,7 +422,7 @@ async function runPrimaryScan(input: ScanPageInput): Promise<{
       url: input.url,
       jsonSchema: toMutableJsonSchema(route.jsonSchema),
       expectedFields: route.expectedFields ? [...route.expectedFields] : undefined,
-      effort: route.effort ?? "low",
+      effort: input.effortOverride ?? route.effort ?? "low",
       nocache,
       geoTarget: input.geoTarget,
       isDemo: input.isDemo,
@@ -467,7 +468,7 @@ async function runPrimaryScan(input: ScanPageInput): Promise<{
       competitorId: input.competitorId,
       pageId: input.pageId,
       url: input.url,
-      effort: "low",
+      effort: input.effortOverride ?? "low",
       nocache,
       geoTarget: input.geoTarget,
       isDemo: input.isDemo,

--- a/lib/tabstack/__tests__/generate.test.ts
+++ b/lib/tabstack/__tests__/generate.test.ts
@@ -593,6 +593,7 @@ describe("generateSelfProfile", () => {
     getTabstackClientMock.mockReturnValue({ generate: { json: generateJsonMock } });
   });
 
+
   it("calls tabstack /generate with SELF_PROFILE_SCHEMA and the provided context", async () => {
     const { generateSelfProfile, SELF_PROFILE_EXPECTED_FIELDS } = await import("@/lib/tabstack/generate");
     const mockProfile = {
@@ -668,5 +669,68 @@ describe("generateSelfProfile", () => {
     expect(metadata.competitorId).toBe("self_1");
     expect(metadata.endpoint).toBe("generate");
     expect(metadata.expectedFields).toEqual(SELF_PROFILE_EXPECTED_FIELDS);
+  });
+});
+
+describe("generateDemoBrief", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loggerCallMock.mockClear();
+    generateJsonMock.mockClear();
+    process.env.TABSTACK_API_KEY = "test-key";
+    loggerCallMock.mockImplementation((fn: () => Promise<unknown>) => fn());
+    toSdkEffortMock.mockImplementation((effort: string) => (effort === "high" ? "max" : "standard"));
+    toGeoTargetMock.mockImplementation((code?: string | null) => {
+      if (!code) return undefined;
+      const n = code.trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(n) ? { country: n } : undefined;
+    });
+    getTabstackClientMock.mockReturnValue({ generate: { json: generateJsonMock } });
+    generateJsonMock.mockResolvedValue({
+      data: { positioning_signal: "p", opportunity: "o", watch_signal: "w" }
+    });
+  });
+
+  it("calls generate.json with DEMO_BRIEF_SCHEMA and effort: low", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    await generateDemoBrief({
+      url: "https://example.com",
+      contextData: '{"homepage": {"primary_tagline": "Hello"}}',
+      isDemo: true
+    });
+
+    expect(generateJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com",
+        effort: "standard", // toSdkEffort("low") => "standard"
+        json_schema: expect.objectContaining({
+          required: expect.arrayContaining(["positioning_signal", "opportunity", "watch_signal"])
+        })
+      })
+    );
+  });
+
+  it("passes isDemo: true to the logger", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    await generateDemoBrief({
+      url: "https://example.com",
+      contextData: "{}",
+      isDemo: true
+    });
+
+    expect(loggerCallMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ endpoint: "generate", isDemo: true, nocache: true })
+    );
+  });
+
+  it("returns the SDK response", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    const result = await generateDemoBrief({ url: "https://example.com", contextData: "{}" });
+
+    expect(result).toEqual({ data: { positioning_signal: "p", opportunity: "o", watch_signal: "w" } });
   });
 });

--- a/lib/tabstack/generate.ts
+++ b/lib/tabstack/generate.ts
@@ -546,3 +546,69 @@ ${contextData}`;
     expectedFields: SELF_PROFILE_EXPECTED_FIELDS
   });
 }
+
+// ---------------------------------------------------------------------------
+// Demo intelligence brief
+// ---------------------------------------------------------------------------
+
+export const DEMO_BRIEF_SCHEMA = {
+  type: "object",
+  properties: {
+    positioning_signal: {
+      type: "string",
+      description: "How this company is positioning itself right now, in one sentence."
+    },
+    opportunity: {
+      type: "string",
+      description: "One specific gap or weakness a competitor could exploit."
+    },
+    watch_signal: {
+      type: "string",
+      description: "One signal worth monitoring in the next competitive cycle."
+    }
+  },
+  required: ["positioning_signal", "opportunity", "watch_signal"]
+} as const;
+
+export const DEMO_BRIEF_EXPECTED_FIELDS: string[] = [...DEMO_BRIEF_SCHEMA.required];
+
+export type GenerateDemoBriefInput = {
+  url: string;
+  contextData: string;
+  isDemo?: boolean;
+};
+
+/**
+ * Synthesize a 3-field intelligence brief from multi-surface demo scan results.
+ * Always uses effort: low and nocache: true. No competitor/page IDs — demo only.
+ */
+export async function generateDemoBrief(input: GenerateDemoBriefInput): Promise<GenerateJsonResponse> {
+  const client = getTabstackClient();
+  const contextData = input.contextData.slice(0, MAX_CONTEXT_LENGTH);
+
+  const instructions = `You are a competitive intelligence analyst. Based on this scan data from ${input.url}, write exactly three things:
+1. How this company is positioning itself right now — one sentence.
+2. One specific gap or weakness a competitor could exploit.
+3. One signal worth monitoring in the next competitive cycle.
+Be direct and specific. No generic advice.
+
+Scan data:
+${contextData}`;
+
+  const requestPayload: GenerateJsonParams = {
+    url: input.url,
+    instructions,
+    json_schema: DEMO_BRIEF_SCHEMA,
+    effort: toSdkEffort("low"),
+    nocache: true
+  };
+
+  return logger.call(() => client.generate.json(requestPayload), {
+    endpoint: "generate",
+    url: input.url,
+    effort: "low",
+    nocache: true,
+    isDemo: input.isDemo,
+    expectedFields: DEMO_BRIEF_EXPECTED_FIELDS
+  });
+}


### PR DESCRIPTION
## Summary

- When a user pastes a root URL into the demo, automatically scans 4 surfaces in parallel: homepage, pricing, blog, careers
- All demo scans use `effort: low` via new `effortOverride` field on `ScanPageInput`
- After page scans complete, synthesizes a 3-field intelligence brief via `/generate`
- Streams results live: `scan:surfaces` → `scan:page_complete` (×4) → `scan:brief_started` → `scan:brief_complete`
- Single-page scans (non-root URLs) are unchanged
- Rate limit counts 1 per user action regardless of surface count

## Files changed

- `lib/scanner.ts` — `effortOverride` on `ScanPageInput`
- `lib/tabstack/generate.ts` — `generateDemoBrief` helper
- `app/api/demo/route.ts` — multi-surface scan path + brief synthesis
- `components/demo/DemoClient.tsx` — multi-surface progress log, stacked results, brief section

## Test plan

- [ ] Paste a root URL (e.g. `https://stripe.com`) — should see 4 surfaces scanned and brief appear
- [ ] Paste a specific-page URL (e.g. `https://stripe.com/pricing`) — existing single-page behavior unchanged
- [ ] Verify 3/day rate limit still works (1 count per demo action, not per surface)
- [ ] `npm run test` passes
- [ ] `npm run build` passes