### PR TITLE
feat(mcp): Rival MCP server — 8 read-only tools covering all competitor data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ notes-local/
 
 # Netlify local link state (per-developer)
 .netlify/
+.worktrees/

--- a/app/api/__tests__/mcp.route.test.ts
+++ b/app/api/__tests__/mcp.route.test.ts
@@ -163,6 +163,8 @@ describe("POST /api/mcp", () => {
       pages: [],
       apiLogs: [{ resultQuality: "full" }, { resultQuality: "partial" }]
     });
+    // No changed scans since pages is empty
+    scanFindManyMock.mockResolvedValue([]);
 
     const { POST } = await import("@/app/api/mcp/route");
     const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor", arguments: { slug: "acme" } }), TOKEN));
@@ -172,6 +174,29 @@ describe("POST /api/mcp", () => {
     expect(result.threat_tier).toBe("high");
     expect(result.manual_data.g2_rating).toBe(4.5);
     expect(result.health_score).toBe(75); // (1 + 0.5) / 2 = 0.75
+  });
+
+  it("tools/call get_competitor surfaces last_changed_at from non-latest scan", async () => {
+    const pageId = "page-1";
+    competitorFindUniqueMock.mockResolvedValue({
+      id: "1", name: "Acme", slug: "acme", baseUrl: "https://acme.com",
+      threatLevel: "High", isSelf: false, manualData: null,
+      pages: [{ id: pageId, type: "pricing", label: "Pricing", url: "https://acme.com/pricing", geoTarget: null, scans: [{ scannedAt: new Date("2026-04-20") }] }],
+      apiLogs: []
+    });
+    // The latest scan (2026-04-20) had no changes; the change was earlier (2026-04-01)
+    scanFindManyMock.mockResolvedValue([
+      { pageId, scannedAt: new Date("2026-04-01"), diffSummary: "Price went up" }
+    ]);
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor", arguments: { slug: "acme" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    const pricingPage = result.tracked_pages.find((p: { page_type: string }) => p.page_type === "pricing");
+    expect(pricingPage.last_checked_at).toBe("2026-04-20T00:00:00.000Z");
+    expect(pricingPage.last_changed_at).toBe("2026-04-01T00:00:00.000Z");
+    expect(pricingPage.latest_summary).toBe("Price went up");
   });
 
   // ── get_intelligence_brief ────────────────────────────────────────────────
@@ -267,6 +292,28 @@ describe("POST /api/mcp", () => {
     const result = JSON.parse(body.result.content[0].text);
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0].summary).toBe("Added MCP support");
+  });
+
+  // ── date validation ───────────────────────────────────────────────────────
+
+  it("tools/call list_recent_intel returns error for invalid since date", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "list_recent_intel", arguments: { since: "not-a-date" } }), TOKEN));
+    const body = await res.json();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("Invalid date");
+    expect(body.error.message).toContain("since");
+  });
+
+  it("tools/call get_competitor_diff returns error for invalid at date", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ id: "1", name: "Acme", isSelf: false });
+    competitorPageFindFirstMock.mockResolvedValue({ id: "p1", url: "https://acme.com/pricing", type: "pricing" });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor_diff", arguments: { competitor: "acme", page_type: "pricing", at: "banana" } }), TOKEN));
+    const body = await res.json();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("Invalid date");
   });
 
   // ── unknown tool ──────────────────────────────────────────────────────────

--- a/app/api/__tests__/mcp.route.test.ts
+++ b/app/api/__tests__/mcp.route.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  competitorFindManyMock,
+  competitorFindUniqueMock,
+  competitorPageFindManyMock,
+  competitorPageFindFirstMock,
+  scanFindManyMock,
+  scanFindFirstMock,
+  deepDiveFindManyMock
+} = vi.hoisted(() => ({
+  competitorFindManyMock: vi.fn(),
+  competitorFindUniqueMock: vi.fn(),
+  competitorPageFindManyMock: vi.fn(),
+  competitorPageFindFirstMock: vi.fn(),
+  scanFindManyMock: vi.fn(),
+  scanFindFirstMock: vi.fn(),
+  deepDiveFindManyMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: { findMany: competitorFindManyMock, findUnique: competitorFindUniqueMock },
+    competitorPage: { findMany: competitorPageFindManyMock, findFirst: competitorPageFindFirstMock },
+    scan: { findMany: scanFindManyMock, findFirst: scanFindFirstMock },
+    deepDive: { findMany: deepDiveFindManyMock }
+  }
+}));
+
+const TOKEN = "test-secret";
+
+function makeRequest(body: unknown, token?: string): NextRequest {
+  return new NextRequest("http://localhost/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token !== undefined ? { authorization: `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+function rpc(method: string, params?: unknown, id = 1) {
+  return { jsonrpc: "2.0", id, method, ...(params !== undefined ? { params } : {}) };
+}
+
+describe("POST /api/mcp", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.RIVAL_MCP_TOKEN = TOKEN;
+  });
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/list")));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong token is provided", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/list"), "wrong-token"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when RIVAL_MCP_TOKEN is not set", async () => {
+    delete process.env.RIVAL_MCP_TOKEN;
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/list"), TOKEN));
+    expect(res.status).toBe(401);
+  });
+
+  // ── MCP protocol ──────────────────────────────────────────────────────────
+
+  it("handles initialize and returns server capabilities", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "claude" } }), TOKEN));
+    const body = await res.json();
+    expect(body.result.protocolVersion).toBe("2024-11-05");
+    expect(body.result.serverInfo.name).toBe("rival");
+    expect(body.result.capabilities.tools).toBeDefined();
+  });
+
+  it("handles notifications/initialized with 202 and no body", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("notifications/initialized"), TOKEN));
+    expect(res.status).toBe(202);
+  });
+
+  it("returns all 8 tools from tools/list", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/list"), TOKEN));
+    const body = await res.json();
+    const names = body.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("list_competitors");
+    expect(names).toContain("get_competitor");
+    expect(names).toContain("get_competitor_data");
+    expect(names).toContain("get_intelligence_brief");
+    expect(names).toContain("get_deep_dives");
+    expect(names).toContain("list_recent_intel");
+    expect(names).toContain("get_competitor_diff");
+    expect(names).toContain("search_intel");
+    expect(names).toHaveLength(8);
+  });
+
+  it("returns 400 for unknown method", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("unknown/method"), TOKEN));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32601);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const req = new NextRequest("http://localhost/api/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+      body: "{ bad json"
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32700);
+  });
+
+  // ── list_competitors ──────────────────────────────────────────────────────
+
+  it("tools/call list_competitors returns sorted competitor list", async () => {
+    competitorFindManyMock.mockResolvedValue([
+      { id: "1", name: "Low Corp", slug: "low-corp", baseUrl: "https://low.co", threatLevel: "Low", isSelf: false, pages: [], apiLogs: [] },
+      { id: "2", name: "High Corp", slug: "high-corp", baseUrl: "https://high.co", threatLevel: "High", isSelf: false, pages: [], apiLogs: [] }
+    ]);
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "list_competitors", arguments: {} }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.competitors[0].slug).toBe("high-corp");
+    expect(result.competitors[1].slug).toBe("low-corp");
+  });
+
+  // ── get_competitor ────────────────────────────────────────────────────────
+
+  it("tools/call get_competitor returns competitor_not_found for unknown slug", async () => {
+    competitorFindUniqueMock.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor", arguments: { slug: "nobody" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.error).toBe("competitor_not_found");
+  });
+
+  it("tools/call get_competitor returns full snapshot", async () => {
+    competitorFindUniqueMock.mockResolvedValue({
+      id: "1", name: "Acme", slug: "acme", baseUrl: "https://acme.com",
+      threatLevel: "High", isSelf: false,
+      manualData: { g2_rating: 4.5, total_funding: "$10M" },
+      pages: [],
+      apiLogs: [{ resultQuality: "full" }, { resultQuality: "partial" }]
+    });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor", arguments: { slug: "acme" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.name).toBe("Acme");
+    expect(result.threat_tier).toBe("high");
+    expect(result.manual_data.g2_rating).toBe(4.5);
+    expect(result.health_score).toBe(75); // (1 + 0.5) / 2 = 0.75
+  });
+
+  // ── get_intelligence_brief ────────────────────────────────────────────────
+
+  it("tools/call get_intelligence_brief returns no_brief_available when brief is null", async () => {
+    competitorFindUniqueMock.mockResolvedValue({
+      name: "Acme", slug: "acme", isSelf: false, intelligenceBrief: null, briefGeneratedAt: null, threatLevel: "High"
+    });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_intelligence_brief", arguments: { slug: "acme" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.error).toBe("no_brief_available");
+  });
+
+  it("tools/call get_intelligence_brief returns all brief fields and axis scores", async () => {
+    competitorFindUniqueMock.mockResolvedValue({
+      name: "Acme", slug: "acme", isSelf: false,
+      threatLevel: "High",
+      briefGeneratedAt: new Date("2026-04-01T00:00:00Z"),
+      intelligenceBrief: {
+        threat_level: "High",
+        threat_reasoning: "Active competitor",
+        positioning_opportunity: "Fill the gap",
+        content_opportunity: "Own the docs space",
+        product_opportunity: "Better SDK",
+        watch_list: ["pricing change", "new hire"],
+        openness_score: 3,
+        brand_trust_score: 7,
+        pricing_score: 6,
+        market_maturity_score: 8,
+        feature_breadth_score: 5,
+        managed_service_score: 9,
+        llm_included_score: 4
+      }
+    });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_intelligence_brief", arguments: { slug: "acme" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.positioning_opportunity).toBe("Fill the gap");
+    expect(result.watch_list).toEqual(["pricing change", "new hire"]);
+    expect(result.axis_scores.openness).toBe(3);
+    expect(result.axis_scores.llm_included).toBe(4);
+  });
+
+  // ── get_competitor_diff ───────────────────────────────────────────────────
+
+  it("tools/call get_competitor_diff truncates content over 8000 chars", async () => {
+    competitorFindUniqueMock.mockResolvedValue({ id: "1", name: "Acme", isSelf: false });
+    competitorPageFindFirstMock.mockResolvedValue({ id: "p1", url: "https://acme.com/pricing", type: "pricing" });
+    scanFindFirstMock
+      .mockResolvedValueOnce({
+        id: "s1",
+        scannedAt: new Date("2026-04-01"),
+        hasChanges: true,
+        rawResult: { tiers: [] },
+        markdownResult: null,
+        diffSummary: "Prices changed"
+      })
+      .mockResolvedValueOnce({
+        id: "s0",
+        scannedAt: new Date("2026-03-01"),
+        rawResult: "x".repeat(9000),
+        markdownResult: null
+      });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "get_competitor_diff", arguments: { competitor: "acme", page_type: "pricing" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.truncated).toBe(true);
+    expect(result.before).toContain("[truncated]");
+  });
+
+  // ── search_intel ──────────────────────────────────────────────────────────
+
+  it("tools/call search_intel returns matching entries", async () => {
+    scanFindManyMock.mockResolvedValue([
+      {
+        id: "s1",
+        scannedAt: new Date("2026-04-10"),
+        diffSummary: "Added MCP support",
+        page: { type: "changelog", url: "https://a.co/changelog", competitor: { name: "Alpha", slug: "alpha" } }
+      }
+    ]);
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "search_intel", arguments: { query: "MCP" } }), TOKEN));
+    const body = await res.json();
+    const result = JSON.parse(body.result.content[0].text);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].summary).toBe("Added MCP support");
+  });
+
+  // ── unknown tool ──────────────────────────────────────────────────────────
+
+  it("tools/call returns error for unknown tool name", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest(rpc("tools/call", { name: "nonexistent_tool", arguments: {} }), TOKEN));
+    const body = await res.json();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("Unknown tool");
+  });
+});

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -50,6 +50,12 @@ function healthScore(logs: Array<{ resultQuality: string | null }>): number {
 
 const TRUNCATE_AT = 8000;
 
+function parseDateArg(s: string, paramName: string): Date {
+  const d = new Date(s);
+  if (isNaN(d.getTime())) throw new Error(`Invalid date for '${paramName}': "${s}"`);
+  return d;
+}
+
 function truncateContent(s: string | null): { content: string | null; wasTruncated: boolean } {
   if (!s) return { content: null, wasTruncated: false };
   if (s.length <= TRUNCATE_AT) return { content: s, wasTruncated: false };
@@ -115,10 +121,11 @@ async function toolGetCompetitor(slug: string) {
     include: {
       pages: {
         include: {
+          // Only latest scan needed for last_checked_at — change data fetched separately below.
           scans: {
             orderBy: { scannedAt: "desc" },
             take: 1,
-            select: { scannedAt: true, hasChanges: true, diffSummary: true }
+            select: { scannedAt: true }
           }
         }
       },
@@ -132,6 +139,19 @@ async function toolGetCompetitor(slug: string) {
   });
 
   if (!c || c.isSelf) return { error: "competitor_not_found", slug };
+
+  // Separate query for last changed scan per page — avoids the take:1 truncation problem
+  // where a page with no recent change would miss older change records.
+  const latestChangedScans =
+    c.pages.length > 0
+      ? await prisma.scan.findMany({
+          where: { pageId: { in: c.pages.map((p) => p.id) }, hasChanges: true },
+          orderBy: { scannedAt: "desc" },
+          distinct: ["pageId"],
+          select: { pageId: true, scannedAt: true, diffSummary: true }
+        })
+      : [];
+  const changedByPageId = new Map(latestChangedScans.map((s) => [s.pageId, s]));
 
   const m = (c.manualData ?? {}) as Record<string, unknown>;
 
@@ -158,15 +178,15 @@ async function toolGetCompetitor(slug: string) {
     },
     tracked_pages: c.pages.map((p) => {
       const latestScan = p.scans[0] ?? null;
-      const latestChange = p.scans.find((s) => s.hasChanges) ?? null;
+      const changedScan = changedByPageId.get(p.id) ?? null;
       return {
         page_type: p.type,
         label: p.label,
         url: p.url,
         geo_target: p.geoTarget ?? null,
         last_checked_at: latestScan?.scannedAt.toISOString() ?? null,
-        last_changed_at: latestChange?.scannedAt.toISOString() ?? null,
-        latest_summary: latestChange?.diffSummary ?? null
+        last_changed_at: changedScan?.scannedAt.toISOString() ?? null,
+        latest_summary: changedScan?.diffSummary ?? null
       };
     })
   };
@@ -307,8 +327,8 @@ async function toolListRecentIntel(params: {
   page_type?: string;
   limit?: number;
 }) {
-  const since = params.since ? new Date(params.since) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-  const until = params.until ? new Date(params.until) : new Date();
+  const since = params.since ? parseDateArg(params.since, "since") : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const until = params.until ? parseDateArg(params.until, "until") : new Date();
   const limit = Math.min(params.limit ?? 50, 200);
 
   const baseWhere = params.competitor
@@ -354,13 +374,15 @@ async function toolGetCompetitorDiff(competitor: string, pageType: string, at?: 
 
   if (!comp || comp.isSelf) return { error: "competitor_not_found", competitor };
 
+  // orderBy: createdAt asc → deterministic when multiple pages share the same type (e.g. geo variants)
   const page = await prisma.competitorPage.findFirst({
-    where: { competitorId: comp.id, type: pageType }
+    where: { competitorId: comp.id, type: pageType },
+    orderBy: { createdAt: "asc" }
   });
 
   if (!page) return { error: "page_type_not_tracked", competitor, page_type: pageType };
 
-  const atFilter = at ? { scannedAt: { lte: new Date(at) } } : {};
+  const atFilter = at ? { scannedAt: { lte: parseDateArg(at, "at") } } : {};
 
   const scan = await prisma.scan.findFirst({
     where: { pageId: page.id, hasChanges: true, ...atFilter },
@@ -390,7 +412,7 @@ async function toolGetCompetitorDiff(competitor: string, pageType: string, at?: 
 }
 
 async function toolSearchIntel(query: string, since?: string, limit = 25) {
-  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const sinceDate = since ? parseDateArg(since, "since") : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const safeLimit = Math.min(limit, 100);
 
   const scans = await prisma.scan.findMany({

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,645 @@
+/**
+ * Rival MCP server — Next.js HTTP endpoint.
+ *
+ * Implements the MCP JSON-RPC protocol directly (no SDK transport adapter needed).
+ * Works as a Netlify serverless function — each request is stateless and short-lived.
+ * All 8 tools are read-only Prisma queries that complete in milliseconds.
+ *
+ * Auth: Bearer token via RIVAL_MCP_TOKEN env var (required).
+ * Endpoint: POST /api/mcp
+ *
+ * MCP client config (Claude Desktop / Claude Code):
+ *   { "url": "https://your-rival.netlify.app/api/mcp", "headers": { "Authorization": "Bearer <token>" } }
+ */
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/db/client";
+
+export const dynamic = "force-dynamic";
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+function isAuthorized(request: NextRequest): boolean {
+  const token = process.env.RIVAL_MCP_TOKEN;
+  if (!token) return false; // No token = deny all — this is production competitive data
+  return request.headers.get("authorization") === `Bearer ${token}`;
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function asObj(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return null;
+}
+
+function threatOrder(level: string | null): number {
+  const l = level?.toLowerCase();
+  if (l === "high") return 0;
+  if (l === "medium") return 1;
+  if (l === "low") return 2;
+  return 3;
+}
+
+function healthScore(logs: Array<{ resultQuality: string | null }>): number {
+  if (logs.length === 0) return 0;
+  const sum = logs.reduce((acc, l) => acc + (l.resultQuality === "full" ? 1 : l.resultQuality === "partial" ? 0.5 : 0), 0);
+  return Math.round((sum / logs.length) * 100);
+}
+
+const TRUNCATE_AT = 8000;
+
+function truncateContent(s: string | null): { content: string | null; wasTruncated: boolean } {
+  if (!s) return { content: null, wasTruncated: false };
+  if (s.length <= TRUNCATE_AT) return { content: s, wasTruncated: false };
+  return { content: s.slice(0, TRUNCATE_AT) + "...[truncated]", wasTruncated: true };
+}
+
+function rawToText(v: unknown): string | null {
+  if (!v) return null;
+  if (typeof v === "string") return v;
+  return JSON.stringify(v, null, 2);
+}
+
+// ── Tool implementations ──────────────────────────────────────────────────────
+
+async function toolListCompetitors() {
+  const competitors = await prisma.competitor.findMany({
+    where: { isSelf: false },
+    include: {
+      pages: {
+        include: {
+          scans: {
+            where: { hasChanges: true },
+            orderBy: { scannedAt: "desc" },
+            take: 1,
+            select: { scannedAt: true }
+          }
+        }
+      },
+      apiLogs: {
+        where: { isDemo: false },
+        orderBy: { calledAt: "desc" },
+        take: 50,
+        select: { resultQuality: true }
+      }
+    }
+  });
+
+  const sorted = [...competitors].sort(
+    (a, b) => threatOrder(a.threatLevel) - threatOrder(b.threatLevel) || a.name.localeCompare(b.name)
+  );
+
+  return {
+    competitors: sorted.map((c) => {
+      const lastChange =
+        c.pages
+          .flatMap((p) => p.scans)
+          .sort((a, b) => b.scannedAt.getTime() - a.scannedAt.getTime())[0]?.scannedAt ?? null;
+      return {
+        name: c.name,
+        slug: c.slug,
+        threat_tier: c.threatLevel?.toLowerCase() ?? "unknown",
+        health_score: healthScore(c.apiLogs),
+        last_change_detected_at: lastChange?.toISOString() ?? null,
+        url: c.baseUrl
+      };
+    })
+  };
+}
+
+async function toolGetCompetitor(slug: string) {
+  const c = await prisma.competitor.findUnique({
+    where: { slug },
+    include: {
+      pages: {
+        include: {
+          scans: {
+            orderBy: { scannedAt: "desc" },
+            take: 1,
+            select: { scannedAt: true, hasChanges: true, diffSummary: true }
+          }
+        }
+      },
+      apiLogs: {
+        where: { isDemo: false },
+        orderBy: { calledAt: "desc" },
+        take: 50,
+        select: { resultQuality: true }
+      }
+    }
+  });
+
+  if (!c || c.isSelf) return { error: "competitor_not_found", slug };
+
+  const m = (c.manualData ?? {}) as Record<string, unknown>;
+
+  return {
+    name: c.name,
+    slug: c.slug,
+    base_url: c.baseUrl,
+    threat_tier: c.threatLevel?.toLowerCase() ?? "unknown",
+    health_score: healthScore(c.apiLogs),
+    manual_data: {
+      founded: m.founded ?? null,
+      employee_count: m.employee_count ?? m.employees ?? null,
+      total_funding: m.total_funding ?? null,
+      last_round: m.last_round ?? null,
+      monthly_traffic: m.monthly_traffic ?? null,
+      traffic_growth_qoq: m.traffic_growth_qoq ?? null,
+      g2_rating: m.g2_rating ?? null,
+      g2_review_count: m.g2_review_count ?? null,
+      capterra_rating: m.capterra_rating ?? null,
+      capterra_review_count: m.capterra_review_count ?? null,
+      praise_themes: m.praise_themes ?? [],
+      complaint_themes: m.complaint_themes ?? [],
+      dev_pain_points: m.dev_pain_points ?? []
+    },
+    tracked_pages: c.pages.map((p) => {
+      const latestScan = p.scans[0] ?? null;
+      const latestChange = p.scans.find((s) => s.hasChanges) ?? null;
+      return {
+        page_type: p.type,
+        label: p.label,
+        url: p.url,
+        geo_target: p.geoTarget ?? null,
+        last_checked_at: latestScan?.scannedAt.toISOString() ?? null,
+        last_changed_at: latestChange?.scannedAt.toISOString() ?? null,
+        latest_summary: latestChange?.diffSummary ?? null
+      };
+    })
+  };
+}
+
+async function toolGetCompetitorData(slug: string, pageType?: string) {
+  const c = await prisma.competitor.findUnique({
+    where: { slug },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!c || c.isSelf) return { error: "competitor_not_found", slug };
+
+  const pages = await prisma.competitorPage.findMany({
+    where: { competitorId: c.id, ...(pageType ? { type: pageType } : {}) },
+    include: {
+      scans: {
+        orderBy: { scannedAt: "desc" },
+        take: 1,
+        select: { scannedAt: true, endpointUsed: true, rawResult: true, markdownResult: true }
+      }
+    }
+  });
+
+  return {
+    competitor: c.name,
+    slug,
+    pages: pages
+      .filter((p) => p.scans.length > 0 && (p.scans[0].rawResult !== null || p.scans[0].markdownResult !== null))
+      .map((p) => {
+        const scan = p.scans[0];
+        const data: unknown =
+          p.type === "changelog" && scan.markdownResult ? { content: scan.markdownResult } : scan.rawResult;
+        return {
+          page_type: p.type,
+          label: p.label,
+          url: p.url,
+          scanned_at: scan.scannedAt.toISOString(),
+          endpoint_used: scan.endpointUsed,
+          data
+        };
+      })
+  };
+}
+
+async function toolGetIntelligenceBrief(slug: string) {
+  const c = await prisma.competitor.findUnique({
+    where: { slug },
+    select: {
+      name: true,
+      slug: true,
+      isSelf: true,
+      intelligenceBrief: true,
+      briefGeneratedAt: true,
+      threatLevel: true
+    }
+  });
+
+  if (!c || c.isSelf) return { error: "competitor_not_found", slug };
+
+  const brief = asObj(c.intelligenceBrief);
+  if (!brief) return { error: "no_brief_available", competitor: c.name, slug };
+
+  return {
+    competitor: c.name,
+    slug: c.slug,
+    generated_at: c.briefGeneratedAt?.toISOString() ?? null,
+    threat_level: typeof brief.threat_level === "string" ? brief.threat_level : c.threatLevel ?? null,
+    threat_reasoning: typeof brief.threat_reasoning === "string" ? brief.threat_reasoning : null,
+    positioning_opportunity: typeof brief.positioning_opportunity === "string" ? brief.positioning_opportunity : null,
+    content_opportunity: typeof brief.content_opportunity === "string" ? brief.content_opportunity : null,
+    product_opportunity: typeof brief.product_opportunity === "string" ? brief.product_opportunity : null,
+    watch_list: Array.isArray(brief.watch_list)
+      ? (brief.watch_list as unknown[]).filter((x): x is string => typeof x === "string")
+      : [],
+    axis_scores: {
+      openness: typeof brief.openness_score === "number" ? brief.openness_score : null,
+      brand_trust: typeof brief.brand_trust_score === "number" ? brief.brand_trust_score : null,
+      pricing: typeof brief.pricing_score === "number" ? brief.pricing_score : null,
+      market_maturity: typeof brief.market_maturity_score === "number" ? brief.market_maturity_score : null,
+      feature_breadth: typeof brief.feature_breadth_score === "number" ? brief.feature_breadth_score : null,
+      managed_service: typeof brief.managed_service_score === "number" ? brief.managed_service_score : null,
+      llm_included: typeof brief.llm_included_score === "number" ? brief.llm_included_score : null
+    }
+  };
+}
+
+async function toolGetDeepDives(slug: string, limit = 3) {
+  const c = await prisma.competitor.findUnique({
+    where: { slug },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!c || c.isSelf) return { error: "competitor_not_found", slug };
+
+  const dives = await prisma.deepDive.findMany({
+    where: { competitorId: c.id },
+    orderBy: { createdAt: "desc" },
+    take: Math.min(limit, 10)
+  });
+
+  return {
+    competitor: c.name,
+    slug,
+    deep_dives: dives.map((dd) => {
+      const result = asObj(dd.result);
+      const report =
+        typeof result?.report === "string"
+          ? result.report
+          : typeof dd.result === "string"
+            ? dd.result
+            : result
+              ? JSON.stringify(result)
+              : null;
+      return {
+        id: dd.id,
+        created_at: dd.createdAt.toISOString(),
+        mode: dd.mode,
+        query: dd.query,
+        report,
+        citations: (Array.isArray(dd.citations) ? dd.citations : []).map((c_: unknown) => {
+          const co = asObj(c_);
+          return {
+            claim: typeof co?.claim === "string" ? co.claim : null,
+            source_url: typeof co?.source_url === "string" ? co.source_url : null,
+            source_text: typeof co?.source_text === "string" ? co.source_text : null
+          };
+        })
+      };
+    })
+  };
+}
+
+async function toolListRecentIntel(params: {
+  since?: string;
+  until?: string;
+  competitor?: string;
+  page_type?: string;
+  limit?: number;
+}) {
+  const since = params.since ? new Date(params.since) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const until = params.until ? new Date(params.until) : new Date();
+  const limit = Math.min(params.limit ?? 50, 200);
+
+  const baseWhere = params.competitor
+    ? { page: { competitor: { slug: params.competitor } } }
+    : { page: { competitor: { isSelf: false } } };
+
+  const scans = await prisma.scan.findMany({
+    where: {
+      hasChanges: true,
+      scannedAt: { gte: since, lte: until },
+      ...(params.page_type ? { page: { ...baseWhere.page, type: params.page_type } } : baseWhere)
+    },
+    include: {
+      page: { include: { competitor: { select: { name: true, slug: true } } } }
+    },
+    orderBy: { scannedAt: "desc" },
+    take: limit + 1
+  });
+
+  const hasMore = scans.length > limit;
+  const entries = scans.slice(0, limit);
+
+  return {
+    entries: entries.map((s) => ({
+      id: s.id,
+      competitor: s.page.competitor.name,
+      competitor_slug: s.page.competitor.slug,
+      page_type: s.page.type,
+      detected_at: s.scannedAt.toISOString(),
+      summary: s.diffSummary ?? null,
+      source_url: s.page.url
+    })),
+    total: entries.length,
+    has_more: hasMore
+  };
+}
+
+async function toolGetCompetitorDiff(competitor: string, pageType: string, at?: string) {
+  const comp = await prisma.competitor.findUnique({
+    where: { slug: competitor },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!comp || comp.isSelf) return { error: "competitor_not_found", competitor };
+
+  const page = await prisma.competitorPage.findFirst({
+    where: { competitorId: comp.id, type: pageType }
+  });
+
+  if (!page) return { error: "page_type_not_tracked", competitor, page_type: pageType };
+
+  const atFilter = at ? { scannedAt: { lte: new Date(at) } } : {};
+
+  const scan = await prisma.scan.findFirst({
+    where: { pageId: page.id, hasChanges: true, ...atFilter },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  if (!scan) return { error: "no_diff_available", competitor, page_type: pageType };
+
+  const prevScan = await prisma.scan.findFirst({
+    where: { pageId: page.id, scannedAt: { lt: scan.scannedAt } },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  const after = truncateContent(rawToText(scan.rawResult) ?? scan.markdownResult);
+  const before = truncateContent(rawToText(prevScan?.rawResult) ?? prevScan?.markdownResult ?? null);
+
+  return {
+    competitor: comp.name,
+    page_type: pageType,
+    detected_at: scan.scannedAt.toISOString(),
+    source_url: page.url,
+    before: before.content,
+    after: after.content,
+    summary: scan.diffSummary ?? null,
+    truncated: after.wasTruncated || before.wasTruncated
+  };
+}
+
+async function toolSearchIntel(query: string, since?: string, limit = 25) {
+  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const safeLimit = Math.min(limit, 100);
+
+  const scans = await prisma.scan.findMany({
+    where: {
+      hasChanges: true,
+      scannedAt: { gte: sinceDate },
+      page: { competitor: { isSelf: false } },
+      OR: [
+        { diffSummary: { contains: query, mode: "insensitive" } },
+        { summary: { contains: query, mode: "insensitive" } }
+      ]
+    },
+    include: {
+      page: { include: { competitor: { select: { name: true, slug: true } } } }
+    },
+    orderBy: { scannedAt: "desc" },
+    take: safeLimit + 1
+  });
+
+  const hasMore = scans.length > safeLimit;
+  const entries = scans.slice(0, safeLimit);
+
+  return {
+    entries: entries.map((s) => ({
+      id: s.id,
+      competitor: s.page.competitor.name,
+      competitor_slug: s.page.competitor.slug,
+      page_type: s.page.type,
+      detected_at: s.scannedAt.toISOString(),
+      summary: s.diffSummary ?? null,
+      source_url: s.page.url
+    })),
+    total: entries.length,
+    has_more: hasMore
+  };
+}
+
+// ── Tool registry ─────────────────────────────────────────────────────────────
+
+type ToolArgs = Record<string, unknown>;
+
+const TOOL_DEFS = [
+  {
+    name: "list_competitors",
+    description:
+      "List all tracked competitors with threat tier, health score, and last change timestamp. Sorted high → low threat.",
+    inputSchema: { type: "object", properties: {}, required: [] }
+  },
+  {
+    name: "get_competitor",
+    description:
+      "Full snapshot for a single competitor — threat tier, health, all tracked pages with last change, and manual data (funding, traffic, G2).",
+    inputSchema: {
+      type: "object",
+      properties: { slug: { type: "string", description: "Competitor slug e.g. 'firecrawl'" } },
+      required: ["slug"]
+    }
+  },
+  {
+    name: "get_competitor_data",
+    description:
+      "Current structured extracted data for a competitor — pricing tiers, open roles, tech stack from JDs, GitHub stats, blog topics, review themes. Optionally filter by page_type.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string" },
+        page_type: {
+          type: "string",
+          description:
+            "Filter to one page type: pricing | careers | github | blog | homepage | profile | reviews | social | docs | stack | changelog"
+        }
+      },
+      required: ["slug"]
+    }
+  },
+  {
+    name: "get_intelligence_brief",
+    description:
+      "AI-generated intelligence brief — positioning/content/product opportunities, threat reasoning, watch list, and all 7 competitive axis scores.",
+    inputSchema: {
+      type: "object",
+      properties: { slug: { type: "string" } },
+      required: ["slug"]
+    }
+  },
+  {
+    name: "get_deep_dives",
+    description:
+      "Research reports from Rival's deep dive feature — multi-pass agentic competitive research with inline citations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string" },
+        limit: { type: "number", description: "Number of reports to return (1–10, default 3)" }
+      },
+      required: ["slug"]
+    }
+  },
+  {
+    name: "list_recent_intel",
+    description: "The intel feed — recent competitor changes, filterable by time window, competitor slug, and page type.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "string", description: "ISO 8601 timestamp (default: 7 days ago)" },
+        until: { type: "string", description: "ISO 8601 timestamp (default: now)" },
+        competitor: { type: "string", description: "Filter by competitor slug" },
+        page_type: { type: "string", description: "Filter by page type" },
+        limit: { type: "number", description: "Max results (default 50, max 200)" }
+      },
+      required: []
+    }
+  },
+  {
+    name: "get_competitor_diff",
+    description:
+      "Before/after content for a specific competitor change. Use to extract exact positioning language, pricing changes, or feature additions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        competitor: { type: "string", description: "Competitor slug" },
+        page_type: { type: "string", description: "Page type to inspect" },
+        at: {
+          type: "string",
+          description: "ISO 8601 timestamp — returns most recent change at or before this time (default: most recent)"
+        }
+      },
+      required: ["competitor", "page_type"]
+    }
+  },
+  {
+    name: "search_intel",
+    description:
+      "Full-text search across the intel feed. Find signals: 'who changed pricing', 'competitors mention MCP', 'DevRel hiring'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        since: { type: "string", description: "ISO 8601 timestamp (default: 30 days ago)" },
+        limit: { type: "number", description: "Max results (default 25, max 100)" }
+      },
+      required: ["query"]
+    }
+  }
+] as const;
+
+async function callTool(name: string, args: ToolArgs): Promise<unknown> {
+  switch (name) {
+    case "list_competitors":
+      return toolListCompetitors();
+    case "get_competitor":
+      return toolGetCompetitor(args.slug as string);
+    case "get_competitor_data":
+      return toolGetCompetitorData(args.slug as string, args.page_type as string | undefined);
+    case "get_intelligence_brief":
+      return toolGetIntelligenceBrief(args.slug as string);
+    case "get_deep_dives":
+      return toolGetDeepDives(args.slug as string, args.limit as number | undefined);
+    case "list_recent_intel":
+      return toolListRecentIntel(
+        args as { since?: string; until?: string; competitor?: string; page_type?: string; limit?: number }
+      );
+    case "get_competitor_diff":
+      return toolGetCompetitorDiff(args.competitor as string, args.page_type as string, args.at as string | undefined);
+    case "search_intel":
+      return toolSearchIntel(args.query as string, args.since as string | undefined, args.limit as number | undefined);
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// ── MCP JSON-RPC handler ──────────────────────────────────────────────────────
+
+const SERVER_INFO = { name: "rival", version: "0.1.0" };
+const PROTOCOL_VERSION = "2024-11-05";
+
+type JsonRpcBody = {
+  jsonrpc: string;
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: JsonRpcBody;
+  try {
+    body = (await request.json()) as JsonRpcBody;
+  } catch {
+    return NextResponse.json(
+      { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+      { status: 400 }
+    );
+  }
+
+  const { id, method, params } = body;
+
+  switch (method) {
+    case "initialize":
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO
+        }
+      });
+
+    case "notifications/initialized":
+      return new NextResponse(null, { status: 202 });
+
+    case "tools/list":
+      return NextResponse.json({ jsonrpc: "2.0", id, result: { tools: TOOL_DEFS } });
+
+    case "tools/call": {
+      const p = params as { name?: string; arguments?: ToolArgs } | undefined;
+      const toolName = p?.name ?? "";
+      const toolArgs = p?.arguments ?? {};
+
+      if (!toolName) {
+        return NextResponse.json(
+          { jsonrpc: "2.0", id, error: { code: -32602, message: "Missing tool name" } },
+          { status: 400 }
+        );
+      }
+
+      try {
+        const result = await callTool(toolName, toolArgs);
+        return NextResponse.json({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] }
+        });
+      } catch (err) {
+        return NextResponse.json(
+          { jsonrpc: "2.0", id, error: { code: -32000, message: err instanceof Error ? err.message : "Tool error" } },
+          { status: 400 }
+        );
+      }
+    }
+
+    default:
+      return NextResponse.json(
+        { jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } },
+        { status: 400 }
+      );
+  }
+}

--- a/docs/superpowers/plans/2026-04-24-demo-multi-surface-scan.md
+++ b/docs/superpowers/plans/2026-04-24-demo-multi-surface-scan.md
@@ -1,0 +1,1233 @@
+# Demo Multi-Surface Scan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a user pastes a root URL into the demo, automatically scan 4 surfaces in parallel (homepage, pricing, blog, careers), stream each result as it lands, and synthesize a 3-field intelligence brief — one URL in, competitive dossier out.
+
+**Architecture:** Add `effortOverride` to `ScanPageInput` so demo scans can force `effort: low` across all page types. Add `generateDemoBrief` for the lightweight post-scan synthesis. Extend the demo route to branch on root-URL detection: root URLs trigger parallel multi-surface scanning with new SSE events; specific-page URLs keep existing single-page behavior unchanged.
+
+**Tech Stack:** Next.js App Router, Vitest, TypeScript strict mode, `@tabstack/sdk`, Prisma, SSE streaming
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `lib/scanner.ts` | Add `effortOverride?: TabstackEffort` to `ScanPageInput`; thread through `runPrimaryScan` |
+| `lib/__tests__/scanner.test.ts` | Add test for `effortOverride` |
+| `lib/tabstack/generate.ts` | Add `DEMO_BRIEF_SCHEMA`, `GenerateDemoBriefInput`, `generateDemoBrief` |
+| `lib/tabstack/__tests__/generate.test.ts` | Add tests for `generateDemoBrief` |
+| `app/api/demo/route.ts` | Add multi-surface scan path; update existing single-page path to pass `effortOverride` |
+| `app/api/__tests__/demo.route.test.ts` | Add multi-surface tests; update existing root-URL tests that break |
+| `components/demo/DemoClient.tsx` | New state, event handlers, multi-surface progress log, stacked results, brief section |
+
+---
+
+## Task 1: Add `effortOverride` to `ScanPageInput`
+
+**Files:**
+- Modify: `lib/scanner.ts`
+- Modify: `lib/__tests__/scanner.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the existing `describe("scanPage", ...)` block in `lib/__tests__/scanner.test.ts`, after the existing pricing test:
+
+```ts
+it("uses effortOverride when provided, ignoring the per-type routing effort", async () => {
+  const { scanPage } = await import("@/lib/scanner");
+
+  await scanPage({
+    competitorId: "cmp_1",
+    pageId: "page_1",
+    url: "https://example.com/pricing",
+    type: "pricing",
+    effortOverride: "low" // pricing normally routes to effort: "high"
+  });
+
+  expect(extractJsonMock).toHaveBeenCalledWith(
+    expect.objectContaining({ effort: "low" })
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run lib/__tests__/scanner.test.ts --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: FAIL — `Expected: "low" / Received: "high"`
+
+- [ ] **Step 3: Add `effortOverride` to `ScanPageInput`**
+
+In `lib/scanner.ts`, add `effortOverride?: TabstackEffort` to the `ScanPageInput` type:
+
+```ts
+export type ScanPageInput = {
+  competitorId?: string | null;
+  pageId?: string | null;
+  label?: string;
+  url: string;
+  type: string;
+  geoTarget?: string | null;
+  nocache?: boolean;
+  isDemo?: boolean;
+  customTask?: string;
+  effortOverride?: TabstackEffort; // forces effort on all Tabstack calls — used by demo mode
+};
+```
+
+- [ ] **Step 4: Thread `effortOverride` through `runPrimaryScan`**
+
+In `lib/scanner.ts`, make three changes inside `runPrimaryScan`:
+
+**Change 1** — the `extract/markdown` branch (around line 381):
+```ts
+// Before:
+effort: route.effort ?? "low",
+// After:
+effort: input.effortOverride ?? route.effort ?? "low",
+```
+
+**Change 2** — the `runJsonExtract` closure (around line 428):
+```ts
+// Before:
+effort: route.effort ?? "low",
+// After:
+effort: input.effortOverride ?? route.effort ?? "low",
+```
+
+**Change 3** — the blog-fallback `extractMarkdown` call (around line 467):
+```ts
+// Before:
+effort: "low",
+// After:
+effort: input.effortOverride ?? "low",
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+npx vitest run lib/__tests__/scanner.test.ts --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Run the full test suite to check for regressions**
+
+```bash
+npx vitest run lib/__tests__/scanner.test.ts
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/scanner.ts lib/__tests__/scanner.test.ts
+git commit -m "feat(scanner): add effortOverride to ScanPageInput for demo mode"
+```
+
+---
+
+## Task 2: Add `generateDemoBrief` to `lib/tabstack/generate.ts`
+
+**Files:**
+- Modify: `lib/tabstack/generate.ts`
+- Modify: `lib/tabstack/__tests__/generate.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe("generateDemoBrief", ...)` block at the end of `lib/tabstack/__tests__/generate.test.ts`. The file already has mock setup for `generateJsonMock`, `loggerCallMock`, `getTabstackClientMock`, `toSdkEffortMock`, and `toGeoTargetMock` in the outer `vi.hoisted` block — reuse them.
+
+```ts
+describe("generateDemoBrief", () => {
+  beforeEach(() => {
+    generateJsonMock.mockResolvedValue({
+      data: { positioning_signal: "p", opportunity: "o", watch_signal: "w" }
+    });
+  });
+
+  it("calls generate.json with DEMO_BRIEF_SCHEMA and effort: low", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    await generateDemoBrief({
+      url: "https://example.com",
+      contextData: '{"homepage": {"primary_tagline": "Hello"}}',
+      isDemo: true
+    });
+
+    expect(generateJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com",
+        effort: "standard", // toSdkEffort("low") => "standard"
+        json_schema: expect.objectContaining({
+          required: expect.arrayContaining(["positioning_signal", "opportunity", "watch_signal"])
+        })
+      })
+    );
+  });
+
+  it("passes isDemo: true to the logger", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    await generateDemoBrief({
+      url: "https://example.com",
+      contextData: "{}",
+      isDemo: true
+    });
+
+    expect(loggerCallMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ endpoint: "generate", isDemo: true, nocache: true })
+    );
+  });
+
+  it("returns the SDK response", async () => {
+    const { generateDemoBrief } = await import("@/lib/tabstack/generate");
+
+    const result = await generateDemoBrief({ url: "https://example.com", contextData: "{}" });
+
+    expect(result).toEqual({ data: { positioning_signal: "p", opportunity: "o", watch_signal: "w" } });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run lib/tabstack/__tests__/generate.test.ts --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: FAIL — `generateDemoBrief is not a function`
+
+- [ ] **Step 3: Add `DEMO_BRIEF_SCHEMA`, type, and function to `lib/tabstack/generate.ts`**
+
+Add the following at the end of `lib/tabstack/generate.ts`, after the `generateSelfProfile` function:
+
+```ts
+// ---------------------------------------------------------------------------
+// Demo intelligence brief
+// ---------------------------------------------------------------------------
+
+export const DEMO_BRIEF_SCHEMA = {
+  type: "object",
+  properties: {
+    positioning_signal: {
+      type: "string",
+      description: "How this company is positioning itself right now, in one sentence."
+    },
+    opportunity: {
+      type: "string",
+      description: "One specific gap or weakness a competitor could exploit."
+    },
+    watch_signal: {
+      type: "string",
+      description: "One signal worth monitoring in the next competitive cycle."
+    }
+  },
+  required: ["positioning_signal", "opportunity", "watch_signal"]
+} as const;
+
+export const DEMO_BRIEF_EXPECTED_FIELDS: string[] = [...DEMO_BRIEF_SCHEMA.required];
+
+export type GenerateDemoBriefInput = {
+  url: string;
+  contextData: string;
+  isDemo?: boolean;
+};
+
+/**
+ * Synthesize a 3-field intelligence brief from multi-surface demo scan results.
+ * Always uses effort: low and nocache: true. No competitor/page IDs — demo only.
+ */
+export async function generateDemoBrief(input: GenerateDemoBriefInput): Promise<GenerateJsonResponse> {
+  const client = getTabstackClient();
+  const contextData = input.contextData.slice(0, MAX_CONTEXT_LENGTH);
+
+  const instructions = `You are a competitive intelligence analyst. Based on this scan data from ${input.url}, write exactly three things:
+1. How this company is positioning itself right now — one sentence.
+2. One specific gap or weakness a competitor could exploit.
+3. One signal worth monitoring in the next competitive cycle.
+Be direct and specific. No generic advice.
+
+Scan data:
+${contextData}`;
+
+  const requestPayload: GenerateJsonParams = {
+    url: input.url,
+    instructions,
+    json_schema: DEMO_BRIEF_SCHEMA,
+    effort: toSdkEffort("low"),
+    nocache: true
+  };
+
+  return logger.call(() => client.generate.json(requestPayload), {
+    endpoint: "generate",
+    url: input.url,
+    effort: "low",
+    nocache: true,
+    isDemo: input.isDemo,
+    expectedFields: DEMO_BRIEF_EXPECTED_FIELDS
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run lib/tabstack/__tests__/generate.test.ts --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/tabstack/generate.ts lib/tabstack/__tests__/generate.test.ts
+git commit -m "feat(generate): add generateDemoBrief for multi-surface demo synthesis"
+```
+
+---
+
+## Task 3: Multi-surface scan logic in `app/api/demo/route.ts`
+
+**Files:**
+- Modify: `app/api/demo/route.ts`
+- Modify: `app/api/__tests__/demo.route.test.ts`
+
+- [ ] **Step 1: Update the mock setup in the test file**
+
+At the top of `app/api/__tests__/demo.route.test.ts`, add `generateDemoBriefMock` to the `vi.hoisted` block and add a `vi.mock` for `@/lib/tabstack/generate`:
+
+```ts
+const {
+  scanPageMock,
+  inferBlogPageTypeMock,
+  demoIpLockCreateMock,
+  demoIpLockDeleteMock,
+  demoScanCountMock,
+  demoScanCreateMock,
+  generateDemoBriefMock   // ← add this
+} = vi.hoisted(() => ({
+  scanPageMock: vi.fn(),
+  inferBlogPageTypeMock: vi.fn(),
+  demoIpLockCreateMock: vi.fn(),
+  demoIpLockDeleteMock: vi.fn(),
+  demoScanCountMock: vi.fn(),
+  demoScanCreateMock: vi.fn(),
+  generateDemoBriefMock: vi.fn()   // ← add this
+}));
+
+vi.mock("@/lib/scanner", () => ({ scanPage: scanPageMock, inferBlogPageType: inferBlogPageTypeMock }));
+vi.mock("@/lib/tabstack/generate", () => ({ generateDemoBrief: generateDemoBriefMock }));  // ← add this
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    demoIpLock: {
+      create: demoIpLockCreateMock,
+      delete: demoIpLockDeleteMock
+    },
+    demoScan: {
+      count: demoScanCountMock,
+      create: demoScanCreateMock
+    }
+  }
+}));
+```
+
+Add `generateDemoBriefMock.mockReset()` to `beforeEach`, and set a default resolution:
+
+```ts
+beforeEach(() => {
+  vi.resetModules();
+  scanPageMock.mockReset();
+  inferBlogPageTypeMock.mockReset();
+  demoIpLockCreateMock.mockReset();
+  demoIpLockDeleteMock.mockReset();
+  demoScanCountMock.mockReset();
+  demoScanCreateMock.mockReset();
+  generateDemoBriefMock.mockReset();   // ← add
+
+  demoIpLockCreateMock.mockResolvedValue({ ipHash: "abc" });
+  demoIpLockDeleteMock.mockResolvedValue({});
+  demoScanCountMock.mockResolvedValue(0);
+  demoScanCreateMock.mockResolvedValue({});
+  scanPageMock.mockResolvedValue(SCAN_RESULT);
+  inferBlogPageTypeMock.mockReturnValue(null);
+  generateDemoBriefMock.mockResolvedValue({   // ← add
+    data: { positioning_signal: "pos", opportunity: "opp", watch_signal: "watch" }
+  });
+});
+```
+
+- [ ] **Step 2: Update existing tests that use a root URL**
+
+The following existing tests use `https://example.com` (a root URL). Once multi-surface is implemented, they will no longer receive `scan:complete`. Update each to use `https://example.com/pricing` instead so they exercise the single-page path:
+
+```ts
+// Change URL in these tests from "https://example.com" to "https://example.com/pricing":
+// - "scan:complete event contains scan result fields"
+// - "creates a demoScan record after a successful scan"
+// - "releases the lock after stream completes successfully"
+// - "emits scan:error and releases lock when scanPage throws"
+// - "emits generic error message for non-Error throws"
+```
+
+For example, the scan:complete test becomes:
+```ts
+it("scan:complete event contains scan result fields", async () => {
+  const { POST } = await import("@/app/api/demo/route");
+  const res = await POST(makeRequest({ url: "https://example.com/pricing" })); // ← changed
+  const events = await drainStream(getBody(res));
+
+  const complete = events.find((e) => e.event === "scan:complete");
+  expect(complete).toBeDefined();
+  const data = complete?.data as { endpointUsed: string; result: unknown };
+  expect(data.endpointUsed).toBe("extract/json");
+  expect(data.result).toEqual(SCAN_RESULT.rawResult);
+});
+```
+
+Apply the same URL change to the other four affected tests.
+
+- [ ] **Step 3: Write the failing multi-surface tests**
+
+Add a new `describe("multi-surface scan (root URL)", ...)` block at the end of `app/api/__tests__/demo.route.test.ts`:
+
+```ts
+describe("multi-surface scan (root URL)", () => {
+  it("emits scan:surfaces with 4 pages for a root URL", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const surfacesEvent = events.find((e) => e.event === "scan:surfaces");
+    expect(surfacesEvent).toBeDefined();
+    const pages = (surfacesEvent?.data as { pages: Array<{ type: string; url: string }> }).pages;
+    expect(pages.map((p) => p.type)).toEqual(["homepage", "pricing", "blog", "careers"]);
+    expect(pages.find((p) => p.type === "homepage")?.url).toBe("https://example.com/");
+    expect(pages.find((p) => p.type === "pricing")?.url).toBe("https://example.com/pricing");
+    expect(pages.find((p) => p.type === "blog")?.url).toBe("https://example.com/blog");
+    expect(pages.find((p) => p.type === "careers")?.url).toBe("https://example.com/careers");
+  });
+
+  it("calls scanPage 4 times with effortOverride: low and isDemo: true", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    await drainStream(getBody(res));
+
+    expect(scanPageMock).toHaveBeenCalledTimes(4);
+    for (const call of scanPageMock.mock.calls) {
+      expect(call[0]).toMatchObject({ effortOverride: "low", isDemo: true });
+    }
+  });
+
+  it("emits scan:page_complete for each non-empty surface result", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const pageCompletes = events.filter((e) => e.event === "scan:page_complete");
+    expect(pageCompletes.length).toBe(4);
+    const types = pageCompletes.map((e) => (e.data as { type: string }).type);
+    expect(types).toContain("homepage");
+    expect(types).toContain("pricing");
+  });
+
+  it("scan:page_complete carries type, url, result, endpointUsed, usedFallback", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const homepageComplete = events.find(
+      (e) => e.event === "scan:page_complete" && (e.data as { type: string }).type === "homepage"
+    );
+    expect(homepageComplete?.data).toMatchObject({
+      type: "homepage",
+      url: "https://example.com/",
+      result: SCAN_RESULT.rawResult,
+      endpointUsed: "extract/json",
+      usedFallback: false
+    });
+  });
+
+  it("emits scan:brief_started then scan:brief_complete after page results", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const names = events.map((e) => e.event);
+    expect(names).toContain("scan:brief_started");
+    expect(names).toContain("scan:brief_complete");
+    const briefIdx = names.indexOf("scan:brief_started");
+    const lastPageIdx = names.lastIndexOf("scan:page_complete");
+    expect(briefIdx).toBeGreaterThan(lastPageIdx);
+  });
+
+  it("scan:brief_complete contains positioning_signal, opportunity, watch_signal", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const briefEvent = events.find((e) => e.event === "scan:brief_complete");
+    expect(briefEvent?.data).toMatchObject({
+      positioning_signal: "pos",
+      opportunity: "opp",
+      watch_signal: "watch"
+    });
+  });
+
+  it("creates exactly 1 demoScan record regardless of surface count", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    await drainStream(getBody(res));
+
+    expect(demoScanCreateMock).toHaveBeenCalledOnce();
+  });
+
+  it("silently drops surfaces with empty rawResult — no scan:page_complete for them", async () => {
+    scanPageMock
+      .mockResolvedValueOnce(SCAN_RESULT)                              // homepage — ok
+      .mockResolvedValueOnce({ ...SCAN_RESULT, rawResult: null })       // pricing — empty
+      .mockResolvedValueOnce(SCAN_RESULT)                              // blog — ok
+      .mockResolvedValueOnce(SCAN_RESULT);                             // careers — ok
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    const pageCompletes = events.filter((e) => e.event === "scan:page_complete");
+    expect(pageCompletes.length).toBe(3);
+    const types = pageCompletes.map((e) => (e.data as { type: string }).type);
+    expect(types).not.toContain("pricing");
+  });
+
+  it("omits brief when all surfaces return empty", async () => {
+    scanPageMock.mockResolvedValue({ ...SCAN_RESULT, rawResult: null });
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    expect(events.find((e) => e.event === "scan:brief_started")).toBeUndefined();
+    expect(events.find((e) => e.event === "scan:brief_complete")).toBeUndefined();
+  });
+
+  it("omits brief silently when generateDemoBrief throws", async () => {
+    generateDemoBriefMock.mockRejectedValueOnce(new Error("Generate failed"));
+
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    // page results still present, no error event from brief failure
+    expect(events.filter((e) => e.event === "scan:page_complete").length).toBe(4);
+    expect(events.find((e) => e.event === "scan:error")).toBeUndefined();
+  });
+
+  it("does not trigger multi-surface for a non-root URL", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com/pricing" }));
+    const events = await drainStream(getBody(res));
+
+    expect(events.find((e) => e.event === "scan:surfaces")).toBeUndefined();
+    expect(scanPageMock).toHaveBeenCalledOnce();
+    expect(events.find((e) => e.event === "scan:complete")).toBeDefined();
+  });
+
+  it("does not emit scan:endpoint or scan:complete for a root URL (multi-surface path)", async () => {
+    const { POST } = await import("@/app/api/demo/route");
+    const res = await POST(makeRequest({ url: "https://example.com" }));
+    const events = await drainStream(getBody(res));
+
+    expect(events.find((e) => e.event === "scan:endpoint")).toBeUndefined();
+    expect(events.find((e) => e.event === "scan:complete")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```bash
+npx vitest run app/api/__tests__/demo.route.test.ts --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: new multi-surface tests FAIL; updated single-page tests PASS (they're already corrected).
+
+- [ ] **Step 5: Implement multi-surface logic in `app/api/demo/route.ts`**
+
+**5a.** Add the import for `generateDemoBrief` and `isPlainObject` at the top of `app/api/demo/route.ts`:
+
+```ts
+import { isPlainObject } from "@/lib/utils/types";
+import { generateDemoBrief } from "@/lib/tabstack/generate";
+```
+
+**5b.** Add two helpers after the existing `isPrivateHost` function:
+
+```ts
+function demoResultIsEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (isPlainObject(v) && Object.keys(v as Record<string, unknown>).length === 0) return true;
+  return false;
+}
+
+function extractDemoBriefData(
+  raw: unknown
+): { positioning_signal: string; opportunity: string; watch_signal: string } | null {
+  const payload = isPlainObject(raw) && "data" in (raw as Record<string, unknown>)
+    ? (raw as Record<string, unknown>).data
+    : raw;
+  if (!isPlainObject(payload)) return null;
+  const d = payload as Record<string, unknown>;
+  if (
+    typeof d.positioning_signal === "string" &&
+    typeof d.opportunity === "string" &&
+    typeof d.watch_signal === "string"
+  ) {
+    return {
+      positioning_signal: d.positioning_signal,
+      opportunity: d.opportunity,
+      watch_signal: d.watch_signal
+    };
+  }
+  return null;
+}
+```
+
+**5c.** Add the `MULTI_SURFACE_TIMEOUT_MS` constant and `buildSurfaces` helper after the existing `SCAN_TIMEOUT_MS` constant:
+
+```ts
+const SCAN_TIMEOUT_MS = 22_000;
+const PER_PAGE_TIMEOUT_MS = 15_000;
+const BRIEF_TIMEOUT_MS = 5_000;
+
+function buildSurfaces(parsedUrl: URL): Array<{ type: string; url: string }> {
+  const base = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+  return [
+    { type: "homepage", url: parsedUrl.toString() },
+    { type: "pricing", url: `${base}/pricing` },
+    { type: "blog", url: `${base}/blog` },
+    { type: "careers", url: `${base}/careers` }
+  ];
+}
+```
+
+**5d.** Replace the stream body inside the `ReadableStream` constructor. Currently the `start` callback has:
+
+```ts
+start: async (controller) => {
+  try {
+    controller.enqueue(sse("scan:started", { url: parsedUrl.toString() }));
+    controller.enqueue(sse("scan:endpoint", { type }));
+
+    const result = await withTimeout(
+      scanPage({
+        url: parsedUrl.toString(),
+        type,
+        isDemo: true,
+        customTask: type === "custom" ? "Extract high-signal competitive intelligence from this page." : undefined
+      }),
+      SCAN_TIMEOUT_MS
+    );
+
+    if (!isLocal) await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+
+    controller.enqueue(
+      sse("scan:complete", {
+        endpointUsed: result.endpointUsed,
+        usedFallback: result.usedFallback,
+        diffSummary: result.diffSummary,
+        hasChanges: result.hasChanges,
+        result: result.rawResult
+      })
+    );
+  } catch (error) {
+    ...
+  } finally {
+    ...
+  }
+}
+```
+
+Replace it with:
+
+```ts
+start: async (controller) => {
+  try {
+    controller.enqueue(sse("scan:started", { url: parsedUrl.toString() }));
+
+    if (type === "homepage") {
+      // ── Multi-surface path ────────────────────────────────────────────
+      const surfaces = buildSurfaces(parsedUrl);
+      controller.enqueue(sse("scan:surfaces", { pages: surfaces }));
+
+      const outcomes = await withTimeout(
+        Promise.allSettled(
+          surfaces.map(({ type: surfaceType, url: surfaceUrl }) =>
+            withTimeout(
+              scanPage({ url: surfaceUrl, type: surfaceType, isDemo: true, effortOverride: "low" }),
+              PER_PAGE_TIMEOUT_MS
+            ).then((result) => ({ type: surfaceType, url: surfaceUrl, result }))
+          )
+        ),
+        SCAN_TIMEOUT_MS
+      );
+
+      const successfulResults: Array<{ type: string; result: unknown }> = [];
+
+      for (const outcome of outcomes) {
+        if (outcome.status === "rejected") continue;
+        const { type: surfaceType, url: surfaceUrl, result } = outcome.value;
+        if (demoResultIsEmpty(result.rawResult)) continue;
+        controller.enqueue(
+          sse("scan:page_complete", {
+            type: surfaceType,
+            url: surfaceUrl,
+            result: result.rawResult,
+            endpointUsed: result.endpointUsed,
+            usedFallback: result.usedFallback
+          })
+        );
+        successfulResults.push({ type: surfaceType, result: result.rawResult });
+      }
+
+      if (successfulResults.length > 0) {
+        controller.enqueue(sse("scan:brief_started", {}));
+        try {
+          const contextData = JSON.stringify(
+            successfulResults.reduce<Record<string, unknown>>((acc, { type: t, result: r }) => {
+              acc[t] = r;
+              return acc;
+            }, {})
+          );
+          const briefRaw = await withTimeout(
+            generateDemoBrief({ url: parsedUrl.toString(), contextData, isDemo: true }),
+            BRIEF_TIMEOUT_MS
+          );
+          const brief = extractDemoBriefData(briefRaw);
+          if (brief) controller.enqueue(sse("scan:brief_complete", brief));
+        } catch {
+          // Brief is a bonus — silently omit on failure or timeout
+        }
+      }
+
+      if (!isLocal) await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+    } else {
+      // ── Single-page path (unchanged) ─────────────────────────────────
+      controller.enqueue(sse("scan:endpoint", { type }));
+
+      const result = await withTimeout(
+        scanPage({
+          url: parsedUrl.toString(),
+          type,
+          isDemo: true,
+          customTask: type === "custom" ? "Extract high-signal competitive intelligence from this page." : undefined
+        }),
+        SCAN_TIMEOUT_MS
+      );
+
+      if (!isLocal) await prisma.demoScan.create({ data: { ipHash: hashedIp } });
+
+      controller.enqueue(
+        sse("scan:complete", {
+          endpointUsed: result.endpointUsed,
+          usedFallback: result.usedFallback,
+          diffSummary: result.diffSummary,
+          hasChanges: result.hasChanges,
+          result: result.rawResult
+        })
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === "scan_timeout") {
+      controller.enqueue(
+        sse("scan:timeout", {
+          message: "Scan exceeded the 22s limit — try a simpler page type (homepage, blog, docs) for faster results."
+        })
+      );
+    } else {
+      controller.enqueue(
+        sse("scan:error", {
+          error: error instanceof Error ? error.message : "Demo scan failed"
+        })
+      );
+    }
+  } finally {
+    if (!isLocal) await releaseLock(hashedIp);
+    controller.close();
+  }
+}
+```
+
+- [ ] **Step 6: Run all demo route tests**
+
+```bash
+npx vitest run app/api/__tests__/demo.route.test.ts --reporter=verbose 2>&1 | tail -40
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | head -30
+```
+
+Expected: no errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/api/demo/route.ts app/api/__tests__/demo.route.test.ts
+git commit -m "feat(demo): multi-surface scan for root URLs — 4 parallel pages + intelligence brief"
+```
+
+---
+
+## Task 4: Update `DemoClient.tsx` for multi-surface UI
+
+**Files:**
+- Modify: `components/demo/DemoClient.tsx`
+
+No unit tests for this task — verify with typecheck and manual browser testing.
+
+- [ ] **Step 1: Add new types at the top of `DemoClient.tsx`**
+
+After the existing `ScanCompleteData` type, add:
+
+```ts
+type ScanSurfaces = {
+  pages: Array<{ type: string; url: string }>;
+};
+
+type PageCompleteData = {
+  type: string;
+  url: string;
+  result: unknown;
+  endpointUsed: string;
+  usedFallback: boolean;
+};
+
+type BriefData = {
+  positioning_signal: string;
+  opportunity: string;
+  watch_signal: string;
+};
+```
+
+- [ ] **Step 2: Add new state and reset in `DemoClient`**
+
+In the `DemoClient` function body, add after the existing state declarations:
+
+```ts
+const [surfaces, setSurfaces] = useState<Array<{ type: string; url: string }>>([]);
+const [pageResults, setPageResults] = useState<PageCompleteData[]>([]);
+const [brief, setBrief] = useState<BriefData | null>(null);
+const [briefPending, setBriefPending] = useState(false);
+```
+
+In `runDemo`, add resets at the top alongside the existing `setEvents([])`:
+
+```ts
+async function runDemo() {
+  setEvents([]);
+  setError(null);
+  setIsRunning(true);
+  setSurfaces([]);
+  setPageResults([]);
+  setBrief(null);
+  setBriefPending(false);
+  // ... rest unchanged
+```
+
+- [ ] **Step 3: Add event handlers for new SSE events in `runDemo`**
+
+Inside the event processing loop (both the main `while` loop chunk and the trailing `buffer` chunk), add handlers alongside the existing `scan:error` and `scan:timeout` checks:
+
+```ts
+if (event.event === "scan:surfaces") {
+  setSurfaces((event.data as ScanSurfaces).pages);
+}
+if (event.event === "scan:page_complete") {
+  setPageResults((prev) => [...prev, event.data as PageCompleteData]);
+}
+if (event.event === "scan:brief_started") {
+  setBriefPending(true);
+}
+if (event.event === "scan:brief_complete") {
+  setBrief(event.data as BriefData);
+  setBriefPending(false);
+}
+```
+
+Add these four blocks in both the main chunk loop and the trailing buffer chunk loop (they are identical — copy them to both locations).
+
+- [ ] **Step 4: Update `hasResult` derivation**
+
+Replace:
+
+```ts
+const completeEvent = events.find((e) => e.event === "scan:complete");
+const hasResult = Boolean(completeEvent);
+```
+
+With:
+
+```ts
+const completeEvent = events.find((e) => e.event === "scan:complete");
+const isMultiSurface = surfaces.length > 0;
+const hasResult = isMultiSurface ? pageResults.length > 0 || briefPending : Boolean(completeEvent);
+```
+
+- [ ] **Step 5: Add `MultiSurfaceProgressLog` component**
+
+Add this component after the existing `ProgressLog` component:
+
+```tsx
+function MultiSurfaceProgressLog({
+  surfaces,
+  pageResults,
+  briefPending,
+  brief,
+  isRunning,
+  startedUrl
+}: {
+  surfaces: Array<{ type: string; url: string }>;
+  pageResults: PageCompleteData[];
+  briefPending: boolean;
+  brief: BriefData | null;
+  isRunning: boolean;
+  startedUrl: string;
+}) {
+  const completedTypes = new Set(pageResults.map((r) => r.type));
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+      <ProgressRow
+        symbol="✓"
+        tone="ok"
+        label="Scan started"
+        detail={startedUrl}
+        done
+      />
+      <ProgressRow
+        symbol="✓"
+        tone="ok"
+        label={`Scanning ${surfaces.length} surfaces`}
+        detail={surfaces.map((s) => s.type).join(" · ")}
+        done
+      />
+      {surfaces.map(({ type }) => {
+        const done = completedTypes.has(type);
+        const running = isRunning && !done;
+        return (
+          <ProgressRow
+            key={type}
+            symbol={done ? "✓" : running ? "→" : "·"}
+            tone={done ? "ok" : running ? "accent" : "faint"}
+            label={done ? `${type} — extracted` : running ? `${type} — extracting…` : type}
+            detail=""
+            done={done}
+          />
+        );
+      })}
+      {(briefPending || brief) && (
+        <ProgressRow
+          symbol={brief ? "✓" : "→"}
+          tone={brief ? "ok" : "accent"}
+          label={brief ? "Intelligence brief — complete" : "Synthesizing brief…"}
+          detail=""
+          done={Boolean(brief)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ProgressRow({
+  symbol,
+  tone,
+  label,
+  detail,
+  done
+}: {
+  symbol: string;
+  tone: "ok" | "accent" | "faint";
+  label: string;
+  detail: string;
+  done: boolean;
+}) {
+  const color =
+    tone === "ok" ? "var(--ok)" : tone === "accent" ? "var(--accent)" : "var(--ink-faint)";
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 14,
+        padding: "10px 0",
+        borderBottom: "1px dotted var(--paper-rule-2)",
+        opacity: done || tone === "accent" ? 1 : 0.35
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 13,
+          color,
+          width: 16,
+          flexShrink: 0
+        }}
+      >
+        {symbol}
+      </span>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>{label}</div>
+        {detail && (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--ink-faint)",
+              marginTop: 2,
+              wordBreak: "break-all"
+            }}
+          >
+            {detail}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Add `MultiSurfaceResults` and `BriefSection` components**
+
+Add these after `MultiSurfaceProgressLog`:
+
+```tsx
+function MultiSurfaceResults({ pageResults }: { pageResults: PageCompleteData[] }) {
+  if (pageResults.length === 0) return null;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+      {pageResults.map((page) => (
+        <div key={page.type}>
+          <div style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
+            <RDSChip tone="solid">{page.type}</RDSChip>
+            <RDSChip tone="solid">{page.endpointUsed}</RDSChip>
+            {page.usedFallback && <RDSChip tone="hot">Fallback triggered</RDSChip>}
+          </div>
+          {isObject(page.result) && Object.keys(page.result).length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+              {Object.entries(page.result as Record<string, unknown>).map(([key, value]) => {
+                const isEmpty =
+                  value === null ||
+                  value === undefined ||
+                  (Array.isArray(value) && value.length === 0) ||
+                  (typeof value === "string" && value.trim().length === 0) ||
+                  (typeof value === "number" && value === 0);
+                return (
+                  <div
+                    key={key}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "200px 1fr",
+                      gap: 16,
+                      padding: "10px 0",
+                      borderBottom: "1px dotted var(--paper-rule-2)",
+                      alignItems: "start",
+                      opacity: isEmpty ? 0.45 : 1
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        letterSpacing: "0.1em",
+                        color: "var(--ink-faint)",
+                        textTransform: "uppercase",
+                        paddingTop: 3
+                      }}
+                    >
+                      {key.replace(/_/g, " ")}
+                    </div>
+                    <div style={{ fontSize: 14, lineHeight: 1.5, color: "var(--ink)" }}>
+                      <ResultValue value={value} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p style={{ color: "var(--ink-faint)", fontStyle: "italic", fontSize: 14, margin: 0 }}>
+              No data extracted — page may have blocked the scan.
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BriefSection({ brief }: { brief: BriefData }) {
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "POSITIONING SIGNAL", value: brief.positioning_signal },
+    { label: "OPPORTUNITY", value: brief.opportunity },
+    { label: "WATCH", value: brief.watch_signal }
+  ];
+  return (
+    <div
+      style={{
+        marginTop: 32,
+        padding: "20px 24px",
+        background: "var(--ink)",
+        color: "var(--ink-bg-text)"
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.18em",
+          color: "var(--ink-ghost)",
+          marginBottom: 16
+        }}
+      >
+        INTELLIGENCE BRIEF
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        {rows.map(({ label, value }) => (
+          <div
+            key={label}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "200px 1fr",
+              gap: 16,
+              padding: "12px 0",
+              borderTop: "1px solid var(--ink-2)"
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                color: "var(--ink-ghost)",
+                paddingTop: 2
+              }}
+            >
+              {label}
+            </div>
+            <div style={{ fontSize: 14, lineHeight: 1.55, textWrap: "pretty" }}>{value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Update the main render in `DemoClient` to branch on multi-surface**
+
+Replace the section that renders progress + results:
+
+```tsx
+{/* Replace the existing events.length > 0 block with: */}
+{events.length > 0 && (
+  <div style={{ display: "grid", gridTemplateColumns: isMultiSurface && hasResult ? "1fr 2fr" : isMultiSurface ? "1fr" : hasResult ? "1fr 2fr" : "1fr", gap: 32 }}>
+    <div>
+      <RDSSectionHead title="Progress" level={3} />
+      {isMultiSurface ? (
+        <MultiSurfaceProgressLog
+          surfaces={surfaces}
+          pageResults={pageResults}
+          briefPending={briefPending}
+          brief={brief}
+          isRunning={isRunning}
+          startedUrl={(events.find((e) => e.event === "scan:started")?.data as { url?: string })?.url ?? ""}
+        />
+      ) : (
+        <ProgressLog events={events} isRunning={isRunning} />
+      )}
+    </div>
+
+    {isMultiSurface && (pageResults.length > 0 || brief) && (
+      <div>
+        <RDSSectionHead title="Extracted Data" level={3} />
+        <MultiSurfaceResults pageResults={pageResults} />
+        {brief && <BriefSection brief={brief} />}
+      </div>
+    )}
+
+    {!isMultiSurface && hasResult && completeEvent && (
+      <div>
+        <RDSSectionHead title="Extracted Data" level={3} />
+        <ScanResult data={completeEvent.data as ScanCompleteData} />
+      </div>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 8: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | head -30
+```
+
+Expected: no errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add components/demo/DemoClient.tsx
+git commit -m "feat(demo): multi-surface UI — stacked page results and intelligence brief section"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass
+
+- [ ] **Step 2: Run build**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+Expected: clean build, no errors
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git checkout -b feat/demo-multi-surface
+git push -u origin feat/demo-multi-surface
+gh pr create \
+  --title "feat(demo): multi-surface scan — 4 parallel pages + intelligence brief" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds parallel multi-surface scanning for root URLs in the demo (homepage, pricing, blog, careers)
+- All demo scans use `effort: low` via new `effortOverride` field on `ScanPageInput`
+- Synthesizes a 3-field intelligence brief via `/generate` after page scans complete
+- Streams results live: `scan:surfaces` → `scan:page_complete` (×4) → `scan:brief_started` → `scan:brief_complete`
+- Single-page scans (non-root URLs) unchanged
+
+## Test plan
+- [ ] Paste a root URL (e.g. `https://stripe.com`) — should see 4 surfaces scanned and brief appear
+- [ ] Paste a specific-page URL (e.g. `https://stripe.com/pricing`) — existing single-page behavior unchanged
+- [ ] Verify 3/day rate limit still works (1 count per demo action, not per surface)
+- [ ] `npm run test` passes
+- [ ] `npm run build` passes
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-24-demo-multi-surface-scan-design.md
+++ b/docs/superpowers/specs/2026-04-24-demo-multi-surface-scan-design.md
@@ -1,0 +1,183 @@
+# Demo Multi-Surface Scan — Design Spec
+
+**Date:** 2026-04-24
+**Status:** Approved
+
+---
+
+## Problem
+
+The demo currently scans one URL and returns one schema's worth of data. The full site scans 8–10 pages per competitor and synthesizes an intelligence brief. A visitor pasting a root URL gets a single homepage schema dump — nowhere near the competitive dossier the product actually produces.
+
+---
+
+## Goal
+
+When a user pastes a root URL into the demo, automatically discover and scan up to 4 surfaces in parallel, stream each result as it lands, then synthesize a 3-field intelligence brief via `/generate`. One URL in → competitive dossier out.
+
+Non-root URL scans (e.g. `/pricing`, `/blog`) retain the current single-page behavior.
+
+---
+
+## Trigger Condition
+
+Multi-surface scanning activates only when `inferPageTypeFromUrl()` returns `"homepage"` — i.e., the URL is a bare root domain with no path. Specific-page URLs skip multi-surface entirely.
+
+---
+
+## Auto-Discovered Surfaces
+
+From the root URL, 4 paths are scanned in parallel:
+
+| Surface | Path attempted | Schema used |
+|---|---|---|
+| Homepage | `{base}/` | `HOMEPAGE_SCHEMA` |
+| Pricing | `{base}/pricing` | `PRICING_SCHEMA` |
+| Blog | `{base}/blog` | `BLOG_SCHEMA` |
+| Careers | `{base}/careers` | `CAREERS_SCHEMA` |
+
+Pages that 404, time out individually, or return empty results are silently dropped — no errors surfaced to the user for missing paths.
+
+All demo scans use `effort: low` regardless of the per-type routing defaults. Pricing and careers normally use `effort: high`; this is the accepted cost trade-off for open demo access.
+
+**Implementation note:** `scanPage()` derives effort from `resolveRouting()` internally — there is no effort override parameter. The multi-surface path should add an `effortOverride?: TabstackEffort` field to `ScanPageInput` and thread it through `runPrimaryScan` → the individual endpoint calls, bypassing the routing table's effort value when set.
+
+---
+
+## SSE Event Stream
+
+### Root URL (multi-surface)
+
+```
+scan:started         { url: string }
+scan:surfaces        { pages: Array<{ type: string; url: string }> }
+scan:page_complete   { type: string; url: string; result: unknown; endpointUsed: string; usedFallback: boolean }
+                     // fires once per page as it completes, in arrival order
+scan:brief_started   {}
+scan:brief_complete  { positioning_signal: string; opportunity: string; watch_signal: string }
+```
+
+### Non-root URL (single-page — unchanged)
+
+```
+scan:started    { url: string }
+scan:endpoint   { type: string }
+scan:complete   { endpointUsed, usedFallback, diffSummary, hasChanges, result }
+```
+
+Error and timeout events (`scan:error`, `scan:timeout`) apply to both paths unchanged.
+
+---
+
+## Timeout Strategy
+
+- **Overall stream:** 22s hard cap (Netlify function limit)
+- **Per-page timeout:** 15s — a slow page is dropped, not waited on
+- **Brief synthesis:** runs after pages complete; if the overall timeout would be exceeded, the brief is omitted silently. Brief is a bonus, not load-bearing.
+
+---
+
+## Intelligence Brief
+
+A single `generateDemoBrief` call (new helper in `lib/tabstack/generate.ts`) after all page scans settle via `Promise.allSettled()`.
+
+JSON schema passed to `/generate`:
+```json
+{
+  "type": "object",
+  "properties": {
+    "positioning_signal": { "type": "string" },
+    "opportunity":        { "type": "string" },
+    "watch_signal":       { "type": "string" }
+  },
+  "required": ["positioning_signal", "opportunity", "watch_signal"]
+}
+```
+
+Prompt: `"You are a competitive intelligence analyst. Based on this scan data from [url], write exactly three things: (1) how this company is positioning itself right now in one sentence, (2) one specific gap or weakness a competitor could exploit, (3) one signal worth monitoring next. Be direct and specific."`
+
+The scan data passed is the concatenated JSON of all successfully extracted page results.
+
+Short prompt, short expected output (~3–5s at `effort: low`). If it fails or times out, the demo still succeeds — the brief section is simply not shown.
+
+---
+
+## Rate Limiting
+
+The `demoScan` DB row is written once per user action regardless of how many parallel API calls fired internally. The user's 3/day quota is consumed by 1, not by the number of surfaces scanned.
+
+---
+
+## UI Changes (`DemoClient.tsx`)
+
+### New TypeScript types
+
+```ts
+type ScanSurfaces = { pages: Array<{ type: string; url: string }> };
+type PageCompleteData = {
+  type: string;
+  url: string;
+  result: unknown;
+  endpointUsed: string;
+  usedFallback: boolean;
+};
+type BriefData = {
+  positioning_signal: string;
+  opportunity: string;
+  watch_signal: string;
+};
+```
+
+### Progress log
+
+Expands to show one row per discovered surface, updating status as each completes:
+
+```
+✓  Scan started — stripe.com
+→  Scanning 4 surfaces: homepage · pricing · blog · careers
+✓  Homepage — extracted
+✓  Pricing — extracted
+✓  Blog — extracted
+→  Careers — extracting…
+```
+
+### Results panel
+
+Replaces the single `ScanResult` block with a stacked layout — one section per page type, rendered in completion order. Each section has a type label chip and uses the existing generic key-value renderer (`ResultValue` / `ResultObject`). No new type-specific rendering required for this PR.
+
+### Brief section
+
+Appears below page results once `scan:brief_complete` fires:
+
+```
+INTELLIGENCE BRIEF
+POSITIONING SIGNAL   "..."
+OPPORTUNITY          "..."
+WATCH                "..."
+```
+
+### Backward compatibility
+
+`scan:endpoint` and `scan:complete` handling is preserved for non-root URL scans. No existing behavior changes for specific-page scans.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/api/demo/route.ts` | Multi-surface scan logic, parallel page scanning, brief synthesis, new SSE events |
+| `components/demo/DemoClient.tsx` | New event handlers, multi-page result display, brief section |
+| `lib/scanner.ts` | Add `effortOverride?: TabstackEffort` to `ScanPageInput`; thread through `runPrimaryScan` to endpoint calls |
+| `lib/tabstack/generate.ts` | Add `generateDemoBrief` helper |
+
+No changes to schemas or the rate-limiting DB models.
+
+---
+
+## Out of Scope
+
+- Type-specific result rendering (pricing as tier table, etc.) — deferred
+- Scanning additional surfaces beyond the 4 listed (docs, github, profile)
+- Configurable surface list
+- Persisting multi-surface demo results to the DB

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,11 @@
+# Required: Prisma connection string
+DATABASE_URL=postgresql://user:password@host:5432/dbname
+
+# Transport: "stdio" (default, for Claude Desktop) or "http" (for remote access)
+RIVAL_MCP_TRANSPORT=stdio
+
+# Required only when RIVAL_MCP_TRANSPORT=http
+RIVAL_MCP_TOKEN=your-secret-token-here
+
+# HTTP port (default: 3100)
+PORT=3100

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,107 @@
+# Rival MCP Server
+
+A standalone MCP server that exposes all Rival competitor intelligence data as read-only tools. Once registered in Claude Desktop or Claude Code, Claude can query your full competitor database directly without any manual data export.
+
+## Quickstart: Claude Desktop
+
+Build the server first:
+
+```bash
+cd mcp && npm install && npm run build
+```
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rival": {
+      "command": "node",
+      "args": ["/absolute/path/to/rival/mcp/dist/index.js"],
+      "env": {
+        "DATABASE_URL": "postgresql://..."
+      }
+    }
+  }
+}
+```
+
+## Quickstart: Claude Code
+
+```bash
+claude mcp add rival -- node /absolute/path/to/rival/mcp/dist/index.js
+```
+
+Set `DATABASE_URL` in your shell environment or pass it via `--env`:
+
+```bash
+claude mcp add rival --env DATABASE_URL=postgresql://... -- node /absolute/path/to/rival/mcp/dist/index.js
+```
+
+## HTTP Mode
+
+For remote access (e.g. a shared team server), set `RIVAL_MCP_TRANSPORT=http`:
+
+```bash
+RIVAL_MCP_TRANSPORT=http \
+RIVAL_MCP_TOKEN=your-secret-token \
+DATABASE_URL=postgresql://... \
+PORT=3100 \
+node mcp/dist/index.js
+```
+
+Test with curl:
+
+```bash
+curl -X POST http://localhost:3100/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## Tools
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `list_competitors` | All tracked competitors sorted high→low threat | — |
+| `get_competitor` | Full snapshot: threat tier, health, pages, funding, traffic, G2 | `slug` |
+| `get_competitor_data` | Structured extracted data: pricing, roles, tech stack, blog topics | `slug`, `page_type?` |
+| `get_intelligence_brief` | AI brief: positioning/content/product opportunities, 7 axis scores | `slug` |
+| `get_deep_dives` | Agentic research reports with citations | `slug`, `limit?` (1-10) |
+| `list_recent_intel` | Intel feed: recent changes filterable by time, competitor, page type | `since?`, `until?`, `competitor?`, `page_type?`, `limit?` |
+| `get_competitor_diff` | Before/after content for a specific change | `competitor`, `page_type`, `at?` |
+| `search_intel` | Full-text search across the intel feed | `query`, `since?`, `limit?` |
+
+## Running Alongside Quiver MCP
+
+Rival MCP is read-only and has no tool name collisions with Quiver. Both servers can be registered simultaneously in Claude Desktop or Claude Code. Use Rival tools for competitive intelligence and Quiver tools for content/campaign management.
+
+Example `claude_desktop_config.json` with both:
+
+```json
+{
+  "mcpServers": {
+    "rival": {
+      "command": "node",
+      "args": ["/path/to/rival/mcp/dist/index.js"],
+      "env": { "DATABASE_URL": "postgresql://..." }
+    },
+    "quiver": {
+      "command": "node",
+      "args": ["/path/to/quiver/mcp/dist/index.js"],
+      "env": { "DATABASE_URL": "postgresql://..." }
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+cd mcp
+npm install
+npm run dev          # run with tsx (no build needed)
+npm run build        # compile to dist/
+npm test             # run vitest
+npm run typecheck    # tsc --noEmit
+```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,8 +1,36 @@
 # Rival MCP Server
 
-A standalone MCP server that exposes all Rival competitor intelligence data as read-only tools. Once registered in Claude Desktop or Claude Code, Claude can query your full competitor database directly without any manual data export.
+Exposes all Rival competitive intelligence as read-only MCP tools. Two modes:
 
-## Quickstart: Claude Desktop
+- **Hosted (Netlify)** — `POST /api/mcp` on your live Rival deployment. No extra infrastructure. Set `RIVAL_MCP_TOKEN` in Netlify env vars, point any MCP client at the URL.
+- **Local stdio** — run the compiled server directly for Claude Desktop.
+
+## Quickstart: Hosted (Netlify)
+
+Set `RIVAL_MCP_TOKEN` in your Netlify environment variables, then configure your MCP client to use the HTTP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "rival": {
+      "url": "https://your-rival.netlify.app/api/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+Test with curl:
+```bash
+curl -X POST https://your-rival.netlify.app/api/mcp \
+  -H "Authorization: Bearer your-token-here" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## Quickstart: Claude Desktop (local stdio)
 
 Build the server first:
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,3894 @@
+{
+  "name": "@rival/mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rival/mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@prisma/adapter-pg": "^7.5.0",
+        "@prisma/client": "^7.5.0",
+        "express": "^4.18.0",
+        "pg": "^8.20.0",
+        "zod": "^3.22.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/node": "^20.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.8.0.tgz",
+      "integrity": "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.8.0",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.8.0.tgz",
+      "integrity": "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.8.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.8.0.tgz",
+      "integrity": "sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+      "integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.8.0.tgz",
+      "integrity": "sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.8.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rival/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@prisma/adapter-pg": "^7.5.0",
+    "@prisma/client": "^7.5.0",
+    "express": "^4.18.0",
+    "pg": "^8.20.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.0",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/mcp/src/db.ts
+++ b/mcp/src/db.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const databaseUrl = process.env.DATABASE_URL;
+
+// Only provide the adapter when DATABASE_URL is available.
+// In test environments the entire module is replaced by vi.mock,
+// so this constructor never runs. In production, DATABASE_URL is required.
+export const prisma = databaseUrl
+  ? new PrismaClient({
+      adapter: new PrismaPg(databaseUrl),
+      log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"]
+    })
+  : new PrismaClient({
+      log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"]
+    });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,22 @@
+import { startStdio } from "./transports/stdio.js";
+import { startHttp } from "./transports/http.js";
+
+const transport = process.env.RIVAL_MCP_TRANSPORT;
+
+if (transport === "http") {
+  const port = parseInt(process.env.PORT ?? "3100", 10);
+  const token = process.env.RIVAL_MCP_TOKEN;
+  if (!token) {
+    console.error("RIVAL_MCP_TOKEN is required for HTTP transport");
+    process.exit(1);
+  }
+  startHttp(port, token).catch((err) => {
+    console.error("Failed to start HTTP transport:", err);
+    process.exit(1);
+  });
+} else {
+  startStdio().catch((err) => {
+    console.error("Failed to start stdio transport:", err);
+    process.exit(1);
+  });
+}

--- a/mcp/src/schemas.ts
+++ b/mcp/src/schemas.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const GetCompetitorSchema = z.object({
+  slug: z.string().min(1)
+});
+
+export const GetCompetitorDataSchema = z.object({
+  slug: z.string().min(1),
+  page_type: z.string().optional()
+});
+
+export const GetIntelligenceBriefSchema = z.object({
+  slug: z.string().min(1)
+});
+
+export const GetDeepDivesSchema = z.object({
+  slug: z.string().min(1),
+  limit: z.number().int().min(1).max(10).optional().default(3)
+});
+
+export const ListRecentIntelSchema = z.object({
+  since: z.string().optional(),
+  until: z.string().optional(),
+  competitor: z.string().optional(),
+  page_type: z.string().optional(),
+  limit: z.number().int().min(1).max(200).optional().default(50)
+});
+
+export const GetCompetitorDiffSchema = z.object({
+  competitor: z.string().min(1),
+  page_type: z.string().min(1),
+  at: z.string().optional()
+});
+
+export const SearchIntelSchema = z.object({
+  query: z.string().min(1),
+  since: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional().default(25)
+});

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,107 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  GetCompetitorSchema,
+  GetCompetitorDataSchema,
+  GetIntelligenceBriefSchema,
+  GetDeepDivesSchema,
+  ListRecentIntelSchema,
+  GetCompetitorDiffSchema,
+  SearchIntelSchema
+} from "./schemas.js";
+import { listCompetitors } from "./tools/list-competitors.js";
+import { getCompetitor } from "./tools/get-competitor.js";
+import { getCompetitorData } from "./tools/get-competitor-data.js";
+import { getIntelligenceBrief } from "./tools/get-intelligence-brief.js";
+import { getDeepDives } from "./tools/get-deep-dives.js";
+import { listRecentIntel } from "./tools/list-recent-intel.js";
+import { getCompetitorDiff } from "./tools/get-competitor-diff.js";
+import { searchIntel } from "./tools/search-intel.js";
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "rival",
+    version: "0.1.0"
+  });
+
+  server.tool(
+    "list_competitors",
+    "List all tracked competitors with threat tier, health score, and last change timestamp. Sorted high → low threat.",
+    {},
+    async () => {
+      const result = await listCompetitors();
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "get_competitor",
+    "Full snapshot for a single competitor — threat tier, health, tracked pages, manual data (funding, traffic, G2).",
+    GetCompetitorSchema.shape,
+    async ({ slug }) => {
+      const result = await getCompetitor(slug);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "get_competitor_data",
+    "Current structured extracted data for a competitor — pricing tiers, open roles, tech stack from JDs, GitHub stats, blog topics, review themes. Optionally filter by page_type.",
+    GetCompetitorDataSchema.shape,
+    async ({ slug, page_type }) => {
+      const result = await getCompetitorData(slug, page_type);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "get_intelligence_brief",
+    "AI-generated intelligence brief — positioning opportunities, content gaps, product opportunities, threat reasoning, watch list, and all 7 competitive axis scores.",
+    GetIntelligenceBriefSchema.shape,
+    async ({ slug }) => {
+      const result = await getIntelligenceBrief(slug);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "get_deep_dives",
+    "Research reports from Rival's deep dive feature — multi-pass agentic competitive research with citations.",
+    GetDeepDivesSchema.shape,
+    async ({ slug, limit }) => {
+      const result = await getDeepDives(slug, limit);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "list_recent_intel",
+    "The intel feed — recent competitor changes, filterable by time window, competitor slug, and page type.",
+    ListRecentIntelSchema.shape,
+    async (params) => {
+      const result = await listRecentIntel(params);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "get_competitor_diff",
+    "Before/after content for a specific competitor change. Use to extract exact positioning language, pricing changes, or feature additions.",
+    GetCompetitorDiffSchema.shape,
+    async ({ competitor, page_type, at }) => {
+      const result = await getCompetitorDiff(competitor, page_type, at);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "search_intel",
+    "Full-text search across the intel feed. Find specific signals: 'who changed pricing', 'which competitors mention MCP', 'DevRel hiring'.",
+    SearchIntelSchema.shape,
+    async ({ query, since, limit }) => {
+      const result = await searchIntel(query, since, limit);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  return server;
+}

--- a/mcp/src/tools/__tests__/get-competitor-data.test.ts
+++ b/mcp/src/tools/__tests__/get-competitor-data.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    competitor: { findUnique: vi.fn() },
+    competitorPage: { findMany: vi.fn() }
+  }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { getCompetitorData } from "../get-competitor-data.js";
+
+const mockCompetitor = { id: "comp-uuid", name: "Acme", isSelf: false };
+const scanDate = new Date("2025-03-01T00:00:00Z");
+
+const makePage = (overrides: {
+  type?: string;
+  label?: string;
+  url?: string;
+  rawResult?: unknown;
+  markdownResult?: string | null;
+  noScans?: boolean;
+}) => ({
+  id: "page-uuid",
+  type: overrides.type ?? "pricing",
+  label: overrides.label ?? "Pricing",
+  url: overrides.url ?? "https://acme.com/pricing",
+  scans: overrides.noScans
+    ? []
+    : [{
+        scannedAt: scanDate,
+        endpointUsed: "extract.json",
+        rawResult: overrides.rawResult ?? null,
+        markdownResult: overrides.markdownResult ?? null
+      }]
+});
+
+describe("getCompetitorData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitor_not_found when competitor does not exist", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(null);
+    const result = await getCompetitorData("missing");
+    expect(result).toEqual({ error: "competitor_not_found", slug: "missing" });
+  });
+
+  it("returns competitor_not_found for isSelf competitors", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue({ ...mockCompetitor, isSelf: true });
+    const result = await getCompetitorData("acme");
+    expect(result).toMatchObject({ error: "competitor_not_found" });
+  });
+
+  it("returns pages with rawResult data", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([
+      makePage({ rawResult: { tiers: ["free", "pro"] } })
+    ]);
+    const result = await getCompetitorData("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].page_type).toBe("pricing");
+    expect(result.pages[0].data).toEqual({ tiers: ["free", "pro"] });
+    expect(result.pages[0].scanned_at).toBe(scanDate.toISOString());
+  });
+
+  it("uses markdownResult content for changelog pages", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([
+      makePage({ type: "changelog", markdownResult: "## v2.0\n- New feature" })
+    ]);
+    const result = await getCompetitorData("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.pages[0].data).toEqual({ content: "## v2.0\n- New feature" });
+  });
+
+  it("filters pages by page_type when provided", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([
+      makePage({ type: "pricing", rawResult: { price: 99 } })
+    ]);
+    await getCompetitorData("acme", "pricing");
+    expect(mockPrisma.competitorPage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ type: "pricing" })
+      })
+    );
+  });
+
+  it("returns empty pages array when no scans exist", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([
+      makePage({ noScans: true })
+    ]);
+    const result = await getCompetitorData("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.pages).toEqual([]);
+  });
+
+  it("excludes pages where both rawResult and markdownResult are null", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([
+      makePage({ rawResult: null, markdownResult: null })
+    ]);
+    const result = await getCompetitorData("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.pages).toEqual([]);
+  });
+
+  it("returns the competitor name and slug", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.competitorPage.findMany.mockResolvedValue([]);
+    const result = await getCompetitorData("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.competitor).toBe("Acme");
+    expect(result.slug).toBe("acme");
+  });
+});

--- a/mcp/src/tools/__tests__/get-competitor-diff.test.ts
+++ b/mcp/src/tools/__tests__/get-competitor-diff.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    competitor: { findUnique: vi.fn() },
+    competitorPage: { findFirst: vi.fn() },
+    scan: { findFirst: vi.fn() }
+  }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { getCompetitorDiff } from "../get-competitor-diff.js";
+
+const mockComp = { id: "comp-uuid", name: "Acme", isSelf: false };
+const mockPage = { id: "page-uuid", url: "https://acme.com/pricing" };
+const scanDate = new Date("2025-04-01T00:00:00Z");
+const prevDate = new Date("2025-03-01T00:00:00Z");
+
+describe("getCompetitorDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitor_not_found when no competitor exists", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(null);
+    const result = await getCompetitorDiff("missing", "pricing");
+    expect(result).toMatchObject({ error: "competitor_not_found", competitor: "missing" });
+  });
+
+  it("returns competitor_not_found for isSelf competitors", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue({ ...mockComp, isSelf: true });
+    const result = await getCompetitorDiff("acme", "pricing");
+    expect(result).toMatchObject({ error: "competitor_not_found" });
+  });
+
+  it("returns page_type_not_tracked when page does not exist", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockComp);
+    mockPrisma.competitorPage.findFirst.mockResolvedValue(null);
+    const result = await getCompetitorDiff("acme", "careers");
+    expect(result).toMatchObject({ error: "page_type_not_tracked", competitor: "acme", page_type: "careers" });
+  });
+
+  it("returns no_diff_available when no scan with hasChanges found", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockComp);
+    mockPrisma.competitorPage.findFirst.mockResolvedValue(mockPage);
+    mockPrisma.scan.findFirst.mockResolvedValueOnce(null);
+    const result = await getCompetitorDiff("acme", "pricing");
+    expect(result).toMatchObject({ error: "no_diff_available", competitor: "acme", page_type: "pricing" });
+  });
+
+  it("returns before/after content for a found diff", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockComp);
+    mockPrisma.competitorPage.findFirst.mockResolvedValue(mockPage);
+    mockPrisma.scan.findFirst
+      .mockResolvedValueOnce({
+        id: "scan-new",
+        scannedAt: scanDate,
+        rawResult: { price: 99 },
+        markdownResult: null,
+        diffSummary: "Price went up"
+      })
+      .mockResolvedValueOnce({
+        id: "scan-old",
+        scannedAt: prevDate,
+        rawResult: { price: 79 },
+        markdownResult: null
+      });
+    const result = await getCompetitorDiff("acme", "pricing");
+    expect(result).toMatchObject({
+      competitor: "Acme",
+      page_type: "pricing",
+      detected_at: scanDate.toISOString(),
+      source_url: "https://acme.com/pricing",
+      summary: "Price went up",
+      truncated: false
+    });
+    expect((result as { after: string }).after).toContain("99");
+    expect((result as { before: string }).before).toContain("79");
+  });
+
+  it("truncates content over 8000 characters and sets truncated=true", async () => {
+    const longContent = "x".repeat(9000);
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockComp);
+    mockPrisma.competitorPage.findFirst.mockResolvedValue(mockPage);
+    mockPrisma.scan.findFirst
+      .mockResolvedValueOnce({
+        id: "scan-new",
+        scannedAt: scanDate,
+        rawResult: null,
+        markdownResult: longContent,
+        diffSummary: null
+      })
+      .mockResolvedValueOnce(null);
+    const result = await getCompetitorDiff("acme", "pricing");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.truncated).toBe(true);
+    expect(result.after).toContain("[truncated]");
+    expect((result.after ?? "").length).toBeLessThan(9000);
+  });
+
+  it("returns null before when no previous scan exists", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockComp);
+    mockPrisma.competitorPage.findFirst.mockResolvedValue(mockPage);
+    mockPrisma.scan.findFirst
+      .mockResolvedValueOnce({
+        id: "scan-new",
+        scannedAt: scanDate,
+        rawResult: { price: 99 },
+        markdownResult: null,
+        diffSummary: null
+      })
+      .mockResolvedValueOnce(null);
+    const result = await getCompetitorDiff("acme", "pricing");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.before).toBeNull();
+  });
+});

--- a/mcp/src/tools/__tests__/get-competitor.test.ts
+++ b/mcp/src/tools/__tests__/get-competitor.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { competitor: { findUnique: vi.fn() } }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { getCompetitor } from "../get-competitor.js";
+
+const makePage = (overrides: {
+  type?: string;
+  label?: string;
+  url?: string;
+  geoTarget?: string | null;
+  scans?: unknown[];
+}) => ({
+  id: "page-uuid",
+  type: overrides.type ?? "pricing",
+  label: overrides.label ?? "Pricing",
+  url: overrides.url ?? "https://acme.com/pricing",
+  geoTarget: overrides.geoTarget ?? null,
+  scans: overrides.scans ?? []
+});
+
+const makeCompetitor = (overrides: {
+  slug?: string;
+  name?: string;
+  isSelf?: boolean;
+  threatLevel?: string | null;
+  manualData?: Record<string, unknown> | null;
+  pages?: ReturnType<typeof makePage>[];
+  apiLogs?: unknown[];
+}) => ({
+  id: "comp-uuid",
+  name: overrides.name ?? "Acme",
+  slug: overrides.slug ?? "acme",
+  baseUrl: "https://acme.com",
+  threatLevel: overrides.threatLevel ?? "High",
+  isSelf: overrides.isSelf ?? false,
+  manualData: overrides.manualData ?? null,
+  pages: overrides.pages ?? [],
+  apiLogs: overrides.apiLogs ?? []
+});
+
+describe("getCompetitor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitor_not_found when no record exists", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(null);
+    const result = await getCompetitor("missing-slug");
+    expect(result).toEqual({ error: "competitor_not_found", slug: "missing-slug" });
+  });
+
+  it("returns competitor_not_found for isSelf competitors", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({ isSelf: true }));
+    const result = await getCompetitor("acme");
+    expect(result).toMatchObject({ error: "competitor_not_found" });
+  });
+
+  it("returns full competitor shape", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({}));
+    const result = await getCompetitor("acme");
+    expect(result).toMatchObject({
+      name: "Acme",
+      slug: "acme",
+      base_url: "https://acme.com",
+      threat_tier: "high"
+    });
+  });
+
+  it("returns manual_data fields from manualData JSON", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({
+        manualData: {
+          founded: 2015,
+          employee_count: 200,
+          total_funding: "$50M",
+          g2_rating: 4.5,
+          g2_review_count: 120,
+          praise_themes: ["easy onboarding"],
+          complaint_themes: ["limited docs"],
+          dev_pain_points: ["no webhooks"]
+        }
+      })
+    );
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.manual_data.founded).toBe(2015);
+    expect(result.manual_data.employee_count).toBe(200);
+    expect(result.manual_data.total_funding).toBe("$50M");
+    expect(result.manual_data.g2_rating).toBe(4.5);
+    expect(result.manual_data.praise_themes).toEqual(["easy onboarding"]);
+  });
+
+  it("uses employees fallback for employee_count", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({ manualData: { employees: 500 } })
+    );
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.manual_data.employee_count).toBe(500);
+  });
+
+  it("returns null manual_data fields when manualData is null", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({ manualData: null }));
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.manual_data.founded).toBeNull();
+    expect(result.manual_data.praise_themes).toEqual([]);
+  });
+
+  it("returns tracked_pages with correct shape", async () => {
+    const scanDate = new Date("2025-03-01T00:00:00Z");
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({
+        pages: [
+          makePage({
+            type: "pricing",
+            label: "Pricing",
+            url: "https://acme.com/pricing",
+            scans: [{ scannedAt: scanDate, hasChanges: false, diffSummary: null }]
+          })
+        ]
+      })
+    );
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.tracked_pages).toHaveLength(1);
+    expect(result.tracked_pages[0]).toMatchObject({
+      page_type: "pricing",
+      label: "Pricing",
+      url: "https://acme.com/pricing",
+      last_checked_at: scanDate.toISOString()
+    });
+  });
+
+  it("returns last_changed_at when scan hasChanges=true", async () => {
+    const changeDate = new Date("2025-04-01T00:00:00Z");
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({
+        pages: [
+          makePage({
+            scans: [{ scannedAt: changeDate, hasChanges: true, diffSummary: "Price went up" }]
+          })
+        ]
+      })
+    );
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.tracked_pages[0].last_changed_at).toBe(changeDate.toISOString());
+    expect(result.tracked_pages[0].latest_summary).toBe("Price went up");
+  });
+
+  it("returns health_score 100 when all logs are full quality", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({
+        apiLogs: [
+          { resultQuality: "full" },
+          { resultQuality: "full" },
+          { resultQuality: "full" }
+        ]
+      })
+    );
+    const result = await getCompetitor("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.health_score).toBe(100);
+  });
+});

--- a/mcp/src/tools/__tests__/get-competitor.test.ts
+++ b/mcp/src/tools/__tests__/get-competitor.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { mockPrisma } = vi.hoisted(() => ({
-  mockPrisma: { competitor: { findUnique: vi.fn() } }
+  mockPrisma: {
+    competitor: { findUnique: vi.fn() },
+    scan: { findMany: vi.fn() }
+  }
 }));
 vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
 
@@ -45,6 +48,7 @@ const makeCompetitor = (overrides: {
 describe("getCompetitor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma.scan.findMany.mockResolvedValue([]); // default: no changed scans
   });
 
   it("returns competitor_not_found when no record exists", async () => {
@@ -136,19 +140,24 @@ describe("getCompetitor", () => {
     });
   });
 
-  it("returns last_changed_at when scan hasChanges=true", async () => {
+  it("returns last_changed_at from the separate changed-scans query", async () => {
+    const checkedDate = new Date("2025-04-10T00:00:00Z");
     const changeDate = new Date("2025-04-01T00:00:00Z");
+    const pageId = "page-uuid";
     mockPrisma.competitor.findUnique.mockResolvedValue(
       makeCompetitor({
         pages: [
-          makePage({
-            scans: [{ scannedAt: changeDate, hasChanges: true, diffSummary: "Price went up" }]
-          })
+          makePage({ scans: [{ scannedAt: checkedDate }] })
         ]
       })
     );
+    // Change recorded by the separate query, not from the inline scans array
+    mockPrisma.scan.findMany.mockResolvedValue([
+      { pageId, scannedAt: changeDate, diffSummary: "Price went up" }
+    ]);
     const result = await getCompetitor("acme");
     if ("error" in result) throw new Error("unexpected error");
+    expect(result.tracked_pages[0].last_checked_at).toBe(checkedDate.toISOString());
     expect(result.tracked_pages[0].last_changed_at).toBe(changeDate.toISOString());
     expect(result.tracked_pages[0].latest_summary).toBe("Price went up");
   });

--- a/mcp/src/tools/__tests__/get-deep-dives.test.ts
+++ b/mcp/src/tools/__tests__/get-deep-dives.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    competitor: { findUnique: vi.fn() },
+    deepDive: { findMany: vi.fn() }
+  }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { getDeepDives } from "../get-deep-dives.js";
+
+const mockCompetitor = { id: "comp-uuid", name: "Acme", isSelf: false };
+const createdAt = new Date("2025-04-01T00:00:00Z");
+
+const makeDeepDive = (overrides: {
+  id?: string;
+  mode?: string;
+  query?: string;
+  result?: unknown;
+  citations?: unknown;
+}) => ({
+  id: overrides.id ?? "dive-uuid",
+  createdAt,
+  mode: overrides.mode ?? "balanced",
+  query: overrides.query ?? "What is their pricing strategy?",
+  result: overrides.result ?? null,
+  citations: overrides.citations ?? null
+});
+
+describe("getDeepDives", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitor_not_found when no record exists", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(null);
+    const result = await getDeepDives("missing");
+    expect(result).toEqual({ error: "competitor_not_found", slug: "missing" });
+  });
+
+  it("returns competitor_not_found for isSelf competitors", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue({ ...mockCompetitor, isSelf: true });
+    const result = await getDeepDives("acme");
+    expect(result).toMatchObject({ error: "competitor_not_found" });
+  });
+
+  it("returns empty array when no deep dives", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.deep_dives).toEqual([]);
+  });
+
+  it("returns report from result.report string", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([
+      makeDeepDive({ result: { report: "Acme uses tiered pricing..." } })
+    ]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.deep_dives[0].report).toBe("Acme uses tiered pricing...");
+  });
+
+  it("falls back to stringified result when result.report is not a string", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([
+      makeDeepDive({ result: { summary: "complex object" } })
+    ]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(typeof result.deep_dives[0].report).toBe("string");
+    expect(result.deep_dives[0].report).toContain("complex object");
+  });
+
+  it("returns null report when result is null", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([makeDeepDive({ result: null })]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.deep_dives[0].report).toBeNull();
+  });
+
+  it("returns citations with claim, source_url, source_text", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([
+      makeDeepDive({
+        result: { report: "Report text" },
+        citations: [
+          { claim: "They raised prices", source_url: "https://acme.com/blog", source_text: "We updated pricing..." }
+        ]
+      })
+    ]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.deep_dives[0].citations).toHaveLength(1);
+    expect(result.deep_dives[0].citations[0]).toEqual({
+      claim: "They raised prices",
+      source_url: "https://acme.com/blog",
+      source_text: "We updated pricing..."
+    });
+  });
+
+  it("returns empty citations array when citations is null", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([makeDeepDive({ citations: null })]);
+    const result = await getDeepDives("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.deep_dives[0].citations).toEqual([]);
+  });
+
+  it("passes the limit parameter to findMany", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(mockCompetitor);
+    mockPrisma.deepDive.findMany.mockResolvedValue([]);
+    await getDeepDives("acme", 5);
+    expect(mockPrisma.deepDive.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 5 })
+    );
+  });
+});

--- a/mcp/src/tools/__tests__/get-intelligence-brief.test.ts
+++ b/mcp/src/tools/__tests__/get-intelligence-brief.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { competitor: { findUnique: vi.fn() } }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { getIntelligenceBrief } from "../get-intelligence-brief.js";
+
+const generatedAt = new Date("2025-04-01T00:00:00Z");
+
+const makeCompetitor = (overrides: {
+  isSelf?: boolean;
+  intelligenceBrief?: unknown;
+  briefGeneratedAt?: Date | null;
+  threatLevel?: string | null;
+}) => ({
+  name: "Acme",
+  slug: "acme",
+  isSelf: overrides.isSelf ?? false,
+  intelligenceBrief: overrides.intelligenceBrief ?? null,
+  briefGeneratedAt: overrides.briefGeneratedAt ?? null,
+  threatLevel: overrides.threatLevel ?? "High"
+});
+
+const fullBrief = {
+  threat_level: "high",
+  threat_reasoning: "Fast growing in our core market",
+  positioning_opportunity: "Emphasize openness",
+  content_opportunity: "Write migration guides",
+  product_opportunity: "Build native webhooks",
+  watch_list: ["pricing page", "hiring"],
+  openness_score: 8,
+  brand_trust_score: 7,
+  pricing_score: 6,
+  market_maturity_score: 5,
+  feature_breadth_score: 4,
+  managed_service_score: 3,
+  llm_included_score: 2
+};
+
+describe("getIntelligenceBrief", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitor_not_found when no record exists", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(null);
+    const result = await getIntelligenceBrief("missing");
+    expect(result).toEqual({ error: "competitor_not_found", slug: "missing" });
+  });
+
+  it("returns competitor_not_found for isSelf competitors", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({ isSelf: true }));
+    const result = await getIntelligenceBrief("acme");
+    expect(result).toMatchObject({ error: "competitor_not_found" });
+  });
+
+  it("returns no_brief_available when intelligenceBrief is null", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({ intelligenceBrief: null }));
+    const result = await getIntelligenceBrief("acme");
+    expect(result).toMatchObject({ error: "no_brief_available", competitor: "Acme", slug: "acme" });
+  });
+
+  it("returns no_brief_available when intelligenceBrief is an array (not an object)", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(makeCompetitor({ intelligenceBrief: [] }));
+    const result = await getIntelligenceBrief("acme");
+    expect(result).toMatchObject({ error: "no_brief_available" });
+  });
+
+  it("returns all brief fields with correct shape", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({ intelligenceBrief: fullBrief, briefGeneratedAt: generatedAt })
+    );
+    const result = await getIntelligenceBrief("acme");
+    expect(result).toMatchObject({
+      competitor: "Acme",
+      slug: "acme",
+      generated_at: generatedAt.toISOString(),
+      threat_level: "high",
+      threat_reasoning: "Fast growing in our core market",
+      positioning_opportunity: "Emphasize openness",
+      content_opportunity: "Write migration guides",
+      product_opportunity: "Build native webhooks",
+      watch_list: ["pricing page", "hiring"]
+    });
+  });
+
+  it("returns all 7 axis_scores", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({ intelligenceBrief: fullBrief, briefGeneratedAt: generatedAt })
+    );
+    const result = await getIntelligenceBrief("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.axis_scores).toEqual({
+      openness: 8,
+      brand_trust: 7,
+      pricing: 6,
+      market_maturity: 5,
+      feature_breadth: 4,
+      managed_service: 3,
+      llm_included: 2
+    });
+  });
+
+  it("falls back to competitor threatLevel when brief.threat_level is missing", async () => {
+    const briefWithoutLevel = { ...fullBrief, threat_level: undefined };
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({ intelligenceBrief: briefWithoutLevel, threatLevel: "Medium" })
+    );
+    const result = await getIntelligenceBrief("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.threat_level).toBe("Medium");
+  });
+
+  it("returns null axis scores when brief is missing those fields", async () => {
+    mockPrisma.competitor.findUnique.mockResolvedValue(
+      makeCompetitor({ intelligenceBrief: { threat_level: "low" } })
+    );
+    const result = await getIntelligenceBrief("acme");
+    if ("error" in result) throw new Error("unexpected error");
+    expect(result.axis_scores.openness).toBeNull();
+    expect(result.axis_scores.pricing).toBeNull();
+  });
+});

--- a/mcp/src/tools/__tests__/list-competitors.test.ts
+++ b/mcp/src/tools/__tests__/list-competitors.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { competitor: { findMany: vi.fn() } }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { listCompetitors } from "../list-competitors.js";
+
+const makeCompetitor = (overrides: {
+  id?: string;
+  name: string;
+  slug: string;
+  baseUrl?: string;
+  threatLevel?: string | null;
+  pages?: unknown[];
+  apiLogs?: unknown[];
+}) => ({
+  id: overrides.id ?? "uuid-1",
+  name: overrides.name,
+  slug: overrides.slug,
+  baseUrl: overrides.baseUrl ?? `https://${overrides.slug}.com`,
+  threatLevel: overrides.threatLevel ?? null,
+  isSelf: false,
+  pages: overrides.pages ?? [],
+  apiLogs: overrides.apiLogs ?? []
+});
+
+describe("listCompetitors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns competitors sorted by threat tier (high before low)", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "Low Co", slug: "low-co", threatLevel: "Low" }),
+      makeCompetitor({ name: "High Co", slug: "high-co", threatLevel: "High" })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0].slug).toBe("high-co");
+    expect(result.competitors[1].slug).toBe("low-co");
+  });
+
+  it("sorts medium between high and low", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "Low Co", slug: "low-co", threatLevel: "Low" }),
+      makeCompetitor({ name: "Medium Co", slug: "medium-co", threatLevel: "Medium" }),
+      makeCompetitor({ name: "High Co", slug: "high-co", threatLevel: "High" })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors.map((c) => c.slug)).toEqual(["high-co", "medium-co", "low-co"]);
+  });
+
+  it("sorts alphabetically within the same threat tier", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "Zebra", slug: "zebra", threatLevel: "High" }),
+      makeCompetitor({ name: "Alpha", slug: "alpha", threatLevel: "High" })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0].slug).toBe("alpha");
+    expect(result.competitors[1].slug).toBe("zebra");
+  });
+
+  it("returns empty array when no competitors", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([]);
+    const result = await listCompetitors();
+    expect(result.competitors).toEqual([]);
+  });
+
+  it("computes health score correctly for full/partial/empty logs", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({
+        name: "Test Co",
+        slug: "test-co",
+        apiLogs: [
+          { resultQuality: "full" },
+          { resultQuality: "full" },
+          { resultQuality: "partial" },
+          { resultQuality: "empty" }
+        ]
+      })
+    ]);
+    const result = await listCompetitors();
+    // (1 + 1 + 0.5 + 0) / 4 = 0.625 → 63%
+    expect(result.competitors[0].health_score).toBe(63);
+  });
+
+  it("returns health_score 0 when no logs", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "No Logs", slug: "no-logs", apiLogs: [] })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0].health_score).toBe(0);
+  });
+
+  it("computes last_change_detected_at from pages with changes", async () => {
+    const earlier = new Date("2025-01-01T00:00:00Z");
+    const later = new Date("2025-06-01T00:00:00Z");
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({
+        name: "Change Co",
+        slug: "change-co",
+        pages: [
+          { scans: [{ scannedAt: earlier }] },
+          { scans: [{ scannedAt: later }] }
+        ]
+      })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0].last_change_detected_at).toBe(later.toISOString());
+  });
+
+  it("returns null for last_change_detected_at when no scans", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "No Changes", slug: "no-changes", pages: [] })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0].last_change_detected_at).toBeNull();
+  });
+
+  it("returns expected shape per competitor", async () => {
+    mockPrisma.competitor.findMany.mockResolvedValue([
+      makeCompetitor({ name: "Acme", slug: "acme", baseUrl: "https://acme.com", threatLevel: "High" })
+    ]);
+    const result = await listCompetitors();
+    expect(result.competitors[0]).toMatchObject({
+      name: "Acme",
+      slug: "acme",
+      threat_tier: "high",
+      url: "https://acme.com"
+    });
+  });
+});

--- a/mcp/src/tools/__tests__/list-recent-intel.test.ts
+++ b/mcp/src/tools/__tests__/list-recent-intel.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { scan: { findMany: vi.fn() } }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { listRecentIntel } from "../list-recent-intel.js";
+
+const makeScan = (overrides: {
+  id?: string;
+  scannedAt?: Date;
+  diffSummary?: string | null;
+  competitorName?: string;
+  competitorSlug?: string;
+  pageType?: string;
+  pageUrl?: string;
+}) => ({
+  id: overrides.id ?? "scan-uuid",
+  scannedAt: overrides.scannedAt ?? new Date("2025-04-01T00:00:00Z"),
+  diffSummary: overrides.diffSummary ?? "Price changed",
+  page: {
+    type: overrides.pageType ?? "pricing",
+    url: overrides.pageUrl ?? "https://acme.com/pricing",
+    competitor: {
+      name: overrides.competitorName ?? "Acme",
+      slug: overrides.competitorSlug ?? "acme"
+    }
+  }
+});
+
+describe("listRecentIntel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns entries in correct shape", async () => {
+    const scanDate = new Date("2025-04-01T00:00:00Z");
+    mockPrisma.scan.findMany.mockResolvedValue([makeScan({ scannedAt: scanDate })]);
+    const result = await listRecentIntel({});
+    expect(result.entries[0]).toMatchObject({
+      id: "scan-uuid",
+      competitor: "Acme",
+      competitor_slug: "acme",
+      page_type: "pricing",
+      detected_at: scanDate.toISOString(),
+      summary: "Price changed",
+      source_url: "https://acme.com/pricing"
+    });
+  });
+
+  it("uses default 7-day window when since is not provided", async () => {
+    const before = Date.now();
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await listRecentIntel({});
+    const after = Date.now();
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    const sinceDate = call.where.scannedAt.gte as Date;
+    const expectedMin = before - 7 * 24 * 60 * 60 * 1000;
+    const expectedMax = after - 7 * 24 * 60 * 60 * 1000;
+    expect(sinceDate.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(sinceDate.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it("filters by competitor slug when provided", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await listRecentIntel({ competitor: "acme" });
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    expect(JSON.stringify(call.where)).toContain("acme");
+  });
+
+  it("filters by page_type when provided", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await listRecentIntel({ page_type: "pricing" });
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    expect(JSON.stringify(call.where)).toContain("pricing");
+  });
+
+  it("sets has_more=true when results exceed limit", async () => {
+    const scans = Array.from({ length: 6 }, (_, i) =>
+      makeScan({ id: `scan-${i}` })
+    );
+    mockPrisma.scan.findMany.mockResolvedValue(scans);
+    const result = await listRecentIntel({ limit: 5 });
+    expect(result.has_more).toBe(true);
+    expect(result.entries).toHaveLength(5);
+  });
+
+  it("sets has_more=false when results are at or below limit", async () => {
+    const scans = Array.from({ length: 3 }, (_, i) =>
+      makeScan({ id: `scan-${i}` })
+    );
+    mockPrisma.scan.findMany.mockResolvedValue(scans);
+    const result = await listRecentIntel({ limit: 5 });
+    expect(result.has_more).toBe(false);
+    expect(result.entries).toHaveLength(3);
+  });
+
+  it("returns empty entries when no scans", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    const result = await listRecentIntel({});
+    expect(result.entries).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.has_more).toBe(false);
+  });
+
+  it("caps limit at MAX_LIMIT (200)", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await listRecentIntel({ limit: 9999 });
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    expect(call.take).toBeLessThanOrEqual(201); // limit + 1
+  });
+});

--- a/mcp/src/tools/__tests__/search-intel.test.ts
+++ b/mcp/src/tools/__tests__/search-intel.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { scan: { findMany: vi.fn() } }
+}));
+vi.mock("../../db.js", () => ({ prisma: mockPrisma }));
+
+import { searchIntel } from "../search-intel.js";
+
+const makeScan = (overrides: {
+  id?: string;
+  scannedAt?: Date;
+  diffSummary?: string | null;
+  competitorName?: string;
+  competitorSlug?: string;
+  pageType?: string;
+  pageUrl?: string;
+}) => ({
+  id: overrides.id ?? "scan-uuid",
+  scannedAt: overrides.scannedAt ?? new Date("2025-04-01T00:00:00Z"),
+  diffSummary: overrides.diffSummary ?? "pricing changed",
+  page: {
+    type: overrides.pageType ?? "pricing",
+    url: overrides.pageUrl ?? "https://acme.com/pricing",
+    competitor: {
+      name: overrides.competitorName ?? "Acme",
+      slug: overrides.competitorSlug ?? "acme"
+    }
+  }
+});
+
+describe("searchIntel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns matching entries in correct shape", async () => {
+    const scanDate = new Date("2025-04-01T00:00:00Z");
+    mockPrisma.scan.findMany.mockResolvedValue([makeScan({ scannedAt: scanDate })]);
+    const result = await searchIntel("pricing");
+    expect(result.entries[0]).toMatchObject({
+      id: "scan-uuid",
+      competitor: "Acme",
+      competitor_slug: "acme",
+      page_type: "pricing",
+      detected_at: scanDate.toISOString(),
+      summary: "pricing changed",
+      source_url: "https://acme.com/pricing"
+    });
+  });
+
+  it("uses ILIKE (case-insensitive) search via Prisma contains+insensitive mode", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await searchIntel("MCP");
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    const orClause = call.where.OR;
+    expect(Array.isArray(orClause)).toBe(true);
+    const hasDiffSummaryFilter = orClause.some(
+      (c: Record<string, unknown>) =>
+        typeof c.diffSummary === "object" &&
+        (c.diffSummary as Record<string, unknown>).mode === "insensitive"
+    );
+    expect(hasDiffSummaryFilter).toBe(true);
+  });
+
+  it("uses default 30-day window when since is not provided", async () => {
+    const before = Date.now();
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await searchIntel("pricing");
+    const after = Date.now();
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    const sinceDate = call.where.scannedAt.gte as Date;
+    const expectedMin = before - 30 * 24 * 60 * 60 * 1000;
+    const expectedMax = after - 30 * 24 * 60 * 60 * 1000;
+    expect(sinceDate.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(sinceDate.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it("respects a custom since date", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await searchIntel("pricing", "2025-01-01T00:00:00Z");
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    expect(call.where.scannedAt.gte).toEqual(new Date("2025-01-01T00:00:00Z"));
+  });
+
+  it("applies the limit and sets has_more=true when exceeded", async () => {
+    const scans = Array.from({ length: 6 }, (_, i) => makeScan({ id: `scan-${i}` }));
+    mockPrisma.scan.findMany.mockResolvedValue(scans);
+    const result = await searchIntel("pricing", undefined, 5);
+    expect(result.has_more).toBe(true);
+    expect(result.entries).toHaveLength(5);
+  });
+
+  it("returns has_more=false when results are at or below limit", async () => {
+    const scans = Array.from({ length: 3 }, (_, i) => makeScan({ id: `scan-${i}` }));
+    mockPrisma.scan.findMany.mockResolvedValue(scans);
+    const result = await searchIntel("pricing", undefined, 5);
+    expect(result.has_more).toBe(false);
+  });
+
+  it("caps limit at 100 even if higher limit is requested", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    await searchIntel("pricing", undefined, 9999);
+    const call = mockPrisma.scan.findMany.mock.calls[0][0];
+    expect(call.take).toBeLessThanOrEqual(101); // limit + 1
+  });
+
+  it("returns empty entries when no results", async () => {
+    mockPrisma.scan.findMany.mockResolvedValue([]);
+    const result = await searchIntel("nonexistent query");
+    expect(result.entries).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.has_more).toBe(false);
+  });
+});

--- a/mcp/src/tools/get-competitor-data.ts
+++ b/mcp/src/tools/get-competitor-data.ts
@@ -1,0 +1,52 @@
+import { prisma } from "../db.js";
+
+export async function getCompetitorData(slug: string, pageType?: string) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { slug },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!competitor || competitor.isSelf) {
+    return { error: "competitor_not_found", slug };
+  }
+
+  const pages = await prisma.competitorPage.findMany({
+    where: {
+      competitorId: competitor.id,
+      ...(pageType ? { type: pageType } : {})
+    },
+    include: {
+      scans: {
+        orderBy: { scannedAt: "desc" },
+        take: 1,
+        select: { scannedAt: true, endpointUsed: true, rawResult: true, markdownResult: true }
+      }
+    }
+  });
+
+  const pagesWithData = pages
+    .filter((p) => p.scans.length > 0)
+    .filter((p) => p.scans[0].rawResult !== null || p.scans[0].markdownResult !== null)
+    .map((p) => {
+      const scan = p.scans[0];
+      const data: unknown =
+        p.type === "changelog" && scan.markdownResult
+          ? { content: scan.markdownResult }
+          : scan.rawResult;
+
+      return {
+        page_type: p.type,
+        label: p.label,
+        url: p.url,
+        scanned_at: scan.scannedAt.toISOString(),
+        endpoint_used: scan.endpointUsed,
+        data
+      };
+    });
+
+  return {
+    competitor: competitor.name,
+    slug,
+    pages: pagesWithData
+  };
+}

--- a/mcp/src/tools/get-competitor-diff.ts
+++ b/mcp/src/tools/get-competitor-diff.ts
@@ -1,0 +1,62 @@
+import { prisma } from "../db.js";
+
+const TRUNCATE_AT = 8000;
+
+function truncate(s: string | null): { content: string | null; truncated: boolean } {
+  if (!s) return { content: null, truncated: false };
+  if (s.length <= TRUNCATE_AT) return { content: s, truncated: false };
+  return { content: s.slice(0, TRUNCATE_AT) + "...[truncated]", truncated: true };
+}
+
+function rawToText(v: unknown): string | null {
+  if (!v) return null;
+  if (typeof v === "string") return v;
+  return JSON.stringify(v, null, 2);
+}
+
+export async function getCompetitorDiff(competitor: string, pageType: string, at?: string) {
+  const comp = await prisma.competitor.findUnique({
+    where: { slug: competitor },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!comp || comp.isSelf) return { error: "competitor_not_found", competitor };
+
+  const page = await prisma.competitorPage.findFirst({
+    where: { competitorId: comp.id, type: pageType }
+  });
+
+  if (!page) return { error: "page_type_not_tracked", competitor, page_type: pageType };
+
+  const atFilter = at ? { scannedAt: { lte: new Date(at) } } : {};
+
+  const scan = await prisma.scan.findFirst({
+    where: { pageId: page.id, hasChanges: true, ...atFilter },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  if (!scan) return { error: "no_diff_available", competitor, page_type: pageType };
+
+  // Get the previous scan to form the "before" content
+  const prevScan = await prisma.scan.findFirst({
+    where: { pageId: page.id, scannedAt: { lt: scan.scannedAt } },
+    orderBy: { scannedAt: "desc" }
+  });
+
+  const afterText = rawToText(scan.rawResult) ?? scan.markdownResult;
+  const beforeText = rawToText(prevScan?.rawResult) ?? prevScan?.markdownResult ?? null;
+
+  const afterTrunc = truncate(afterText ?? null);
+  const beforeTrunc = truncate(beforeText);
+
+  return {
+    competitor: comp.name,
+    page_type: pageType,
+    detected_at: scan.scannedAt.toISOString(),
+    source_url: page.url,
+    before: beforeTrunc.content,
+    after: afterTrunc.content,
+    summary: scan.diffSummary ?? null,
+    truncated: afterTrunc.truncated || beforeTrunc.truncated
+  };
+}

--- a/mcp/src/tools/get-competitor-diff.ts
+++ b/mcp/src/tools/get-competitor-diff.ts
@@ -22,12 +22,18 @@ export async function getCompetitorDiff(competitor: string, pageType: string, at
 
   if (!comp || comp.isSelf) return { error: "competitor_not_found", competitor };
 
+  // orderBy: createdAt asc → deterministic when multiple pages share the same type (e.g. geo variants)
   const page = await prisma.competitorPage.findFirst({
-    where: { competitorId: comp.id, type: pageType }
+    where: { competitorId: comp.id, type: pageType },
+    orderBy: { createdAt: "asc" }
   });
 
   if (!page) return { error: "page_type_not_tracked", competitor, page_type: pageType };
 
+  if (at !== undefined) {
+    const parsed = new Date(at);
+    if (isNaN(parsed.getTime())) throw new Error(`Invalid date for 'at': "${at}"`);
+  }
   const atFilter = at ? { scannedAt: { lte: new Date(at) } } : {};
 
   const scan = await prisma.scan.findFirst({

--- a/mcp/src/tools/get-competitor.ts
+++ b/mcp/src/tools/get-competitor.ts
@@ -14,10 +14,11 @@ export async function getCompetitor(slug: string) {
     include: {
       pages: {
         include: {
+          // Only latest scan for last_checked_at — change data fetched separately below.
           scans: {
             orderBy: { scannedAt: "desc" },
             take: 1,
-            select: { scannedAt: true, hasChanges: true, diffSummary: true }
+            select: { scannedAt: true }
           }
         }
       },
@@ -33,6 +34,18 @@ export async function getCompetitor(slug: string) {
   if (!competitor || competitor.isSelf) {
     return { error: "competitor_not_found", slug };
   }
+
+  // Separate query for last changed scan per page — avoids the take:1 truncation problem.
+  const latestChangedScans =
+    competitor.pages.length > 0
+      ? await prisma.scan.findMany({
+          where: { pageId: { in: competitor.pages.map((p) => p.id) }, hasChanges: true },
+          orderBy: { scannedAt: "desc" },
+          distinct: ["pageId"],
+          select: { pageId: true, scannedAt: true, diffSummary: true }
+        })
+      : [];
+  const changedByPageId = new Map(latestChangedScans.map((s) => [s.pageId, s]));
 
   const manual = (competitor.manualData ?? {}) as Record<string, unknown>;
 
@@ -60,15 +73,15 @@ export async function getCompetitor(slug: string) {
     },
     tracked_pages: competitor.pages.map((p) => {
       const latestScan = p.scans[0] ?? null;
-      const latestChange = p.scans.find((s) => s.hasChanges) ?? null;
+      const changedScan = changedByPageId.get(p.id) ?? null;
       return {
         page_type: p.type,
         label: p.label,
         url: p.url,
         geo_target: p.geoTarget ?? null,
         last_checked_at: latestScan?.scannedAt.toISOString() ?? null,
-        last_changed_at: latestChange?.scannedAt.toISOString() ?? null,
-        latest_summary: latestChange?.diffSummary ?? null
+        last_changed_at: changedScan?.scannedAt.toISOString() ?? null,
+        latest_summary: changedScan?.diffSummary ?? null
       };
     })
   };

--- a/mcp/src/tools/get-competitor.ts
+++ b/mcp/src/tools/get-competitor.ts
@@ -1,0 +1,75 @@
+import { prisma } from "../db.js";
+
+function computeHealthScore(logs: Array<{ resultQuality: string | null }>): number {
+  if (logs.length === 0) return 0;
+  const score = logs.reduce((sum, l) => {
+    return sum + (l.resultQuality === "full" ? 1 : l.resultQuality === "partial" ? 0.5 : 0);
+  }, 0);
+  return Math.round((score / logs.length) * 100);
+}
+
+export async function getCompetitor(slug: string) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { slug },
+    include: {
+      pages: {
+        include: {
+          scans: {
+            orderBy: { scannedAt: "desc" },
+            take: 1,
+            select: { scannedAt: true, hasChanges: true, diffSummary: true }
+          }
+        }
+      },
+      apiLogs: {
+        where: { isDemo: false },
+        orderBy: { calledAt: "desc" },
+        take: 50,
+        select: { resultQuality: true }
+      }
+    }
+  });
+
+  if (!competitor || competitor.isSelf) {
+    return { error: "competitor_not_found", slug };
+  }
+
+  const manual = (competitor.manualData ?? {}) as Record<string, unknown>;
+
+  return {
+    name: competitor.name,
+    slug: competitor.slug,
+    base_url: competitor.baseUrl,
+    threat_tier: competitor.threatLevel?.toLowerCase() ?? "unknown",
+    health_score: computeHealthScore(competitor.apiLogs),
+    manual_data: {
+      founded: manual.founded ?? null,
+      employee_count: manual.employee_count ?? manual.employees ?? null,
+      total_funding: manual.total_funding ?? null,
+      last_round: manual.last_round ?? null,
+      monthly_traffic: manual.monthly_traffic ?? null,
+      traffic_growth_qoq: manual.traffic_growth_qoq ?? null,
+      domain_authority: manual.domain_authority ?? null,
+      g2_rating: manual.g2_rating ?? null,
+      g2_review_count: manual.g2_review_count ?? null,
+      capterra_rating: manual.capterra_rating ?? null,
+      capterra_review_count: manual.capterra_review_count ?? null,
+      praise_themes: manual.praise_themes ?? [],
+      complaint_themes: manual.complaint_themes ?? [],
+      dev_pain_points: manual.dev_pain_points ?? []
+    },
+    tracked_pages: competitor.pages.map((p) => {
+      const latestScan = p.scans[0] ?? null;
+      const latestChange = p.scans.find((s) => s.hasChanges) ?? null;
+      return {
+        page_type: p.type,
+        label: p.label,
+        url: p.url,
+        geo_target: p.geoTarget ?? null,
+        last_checked_at: latestScan?.scannedAt.toISOString() ?? null,
+        last_changed_at: latestChange?.scannedAt.toISOString() ?? null,
+        latest_summary: latestChange?.diffSummary ?? null
+      };
+    })
+  };
+}

--- a/mcp/src/tools/get-deep-dives.ts
+++ b/mcp/src/tools/get-deep-dives.ts
@@ -1,0 +1,57 @@
+import { prisma } from "../db.js";
+
+function asObj(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return null;
+}
+
+export async function getDeepDives(slug: string, limit = 3) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { slug },
+    select: { id: true, name: true, isSelf: true }
+  });
+
+  if (!competitor || competitor.isSelf) {
+    return { error: "competitor_not_found", slug };
+  }
+
+  const deepDives = await prisma.deepDive.findMany({
+    where: { competitorId: competitor.id },
+    orderBy: { createdAt: "desc" },
+    take: limit
+  });
+
+  return {
+    competitor: competitor.name,
+    slug,
+    deep_dives: deepDives.map((dd) => {
+      const result = asObj(dd.result);
+      const report =
+        typeof result?.report === "string"
+          ? result.report
+          : typeof dd.result === "string"
+            ? dd.result
+            : result
+              ? JSON.stringify(result)
+              : null;
+
+      const citations = Array.isArray(dd.citations) ? dd.citations : [];
+
+      return {
+        id: dd.id,
+        created_at: dd.createdAt.toISOString(),
+        mode: dd.mode,
+        query: dd.query,
+        report,
+        citations: citations.map((c: unknown) => {
+          const co = asObj(c);
+          return {
+            claim: typeof co?.claim === "string" ? co.claim : null,
+            source_url: typeof co?.source_url === "string" ? co.source_url : null,
+            source_text: typeof co?.source_text === "string" ? co.source_text : null
+          };
+        })
+      };
+    })
+  };
+}

--- a/mcp/src/tools/get-intelligence-brief.ts
+++ b/mcp/src/tools/get-intelligence-brief.ts
@@ -1,0 +1,52 @@
+import { prisma } from "../db.js";
+
+function asObj(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return null;
+}
+
+export async function getIntelligenceBrief(slug: string) {
+  const competitor = await prisma.competitor.findUnique({
+    where: { slug },
+    select: {
+      name: true,
+      slug: true,
+      isSelf: true,
+      intelligenceBrief: true,
+      briefGeneratedAt: true,
+      threatLevel: true
+    }
+  });
+
+  if (!competitor || competitor.isSelf) {
+    return { error: "competitor_not_found", slug };
+  }
+
+  const brief = asObj(competitor.intelligenceBrief);
+  if (!brief) {
+    return { error: "no_brief_available", competitor: competitor.name, slug };
+  }
+
+  return {
+    competitor: competitor.name,
+    slug: competitor.slug,
+    generated_at: competitor.briefGeneratedAt?.toISOString() ?? null,
+    threat_level: typeof brief.threat_level === "string" ? brief.threat_level : competitor.threatLevel ?? null,
+    threat_reasoning: typeof brief.threat_reasoning === "string" ? brief.threat_reasoning : null,
+    positioning_opportunity: typeof brief.positioning_opportunity === "string" ? brief.positioning_opportunity : null,
+    content_opportunity: typeof brief.content_opportunity === "string" ? brief.content_opportunity : null,
+    product_opportunity: typeof brief.product_opportunity === "string" ? brief.product_opportunity : null,
+    watch_list: Array.isArray(brief.watch_list)
+      ? (brief.watch_list as unknown[]).filter((x): x is string => typeof x === "string")
+      : [],
+    axis_scores: {
+      openness: typeof brief.openness_score === "number" ? brief.openness_score : null,
+      brand_trust: typeof brief.brand_trust_score === "number" ? brief.brand_trust_score : null,
+      pricing: typeof brief.pricing_score === "number" ? brief.pricing_score : null,
+      market_maturity: typeof brief.market_maturity_score === "number" ? brief.market_maturity_score : null,
+      feature_breadth: typeof brief.feature_breadth_score === "number" ? brief.feature_breadth_score : null,
+      managed_service: typeof brief.managed_service_score === "number" ? brief.managed_service_score : null,
+      llm_included: typeof brief.llm_included_score === "number" ? brief.llm_included_score : null
+    }
+  };
+}

--- a/mcp/src/tools/list-competitors.ts
+++ b/mcp/src/tools/list-competitors.ts
@@ -1,0 +1,62 @@
+import { prisma } from "../db.js";
+
+function threatOrder(level: string | null): number {
+  if (level?.toLowerCase() === "high") return 0;
+  if (level?.toLowerCase() === "medium") return 1;
+  if (level?.toLowerCase() === "low") return 2;
+  return 3;
+}
+
+function computeHealthScore(logs: Array<{ resultQuality: string | null }>): number {
+  if (logs.length === 0) return 0;
+  const score = logs.reduce((sum, l) => {
+    return sum + (l.resultQuality === "full" ? 1 : l.resultQuality === "partial" ? 0.5 : 0);
+  }, 0);
+  return Math.round((score / logs.length) * 100);
+}
+
+export async function listCompetitors() {
+  const competitors = await prisma.competitor.findMany({
+    where: { isSelf: false },
+    include: {
+      pages: {
+        include: {
+          scans: {
+            where: { hasChanges: true },
+            orderBy: { scannedAt: "desc" },
+            take: 1,
+            select: { scannedAt: true }
+          }
+        }
+      },
+      apiLogs: {
+        where: { isDemo: false },
+        orderBy: { calledAt: "desc" },
+        take: 50,
+        select: { resultQuality: true }
+      }
+    }
+  });
+
+  const sorted = [...competitors].sort((a, b) =>
+    threatOrder(a.threatLevel) - threatOrder(b.threatLevel) ||
+    a.name.localeCompare(b.name)
+  );
+
+  return {
+    competitors: sorted.map((c) => {
+      const lastChange = c.pages
+        .flatMap((p) => p.scans)
+        .sort((a, b) => b.scannedAt.getTime() - a.scannedAt.getTime())[0]?.scannedAt ?? null;
+
+      return {
+        name: c.name,
+        slug: c.slug,
+        threat_tier: c.threatLevel?.toLowerCase() ?? "unknown",
+        health_score: computeHealthScore(c.apiLogs),
+        last_change_detected_at: lastChange?.toISOString() ?? null,
+        url: `${c.baseUrl}`
+      };
+    })
+  };
+}

--- a/mcp/src/tools/list-recent-intel.ts
+++ b/mcp/src/tools/list-recent-intel.ts
@@ -2,6 +2,12 @@ import { prisma } from "../db.js";
 
 const MAX_LIMIT = 200;
 
+function parseDateArg(s: string, paramName: string): Date {
+  const d = new Date(s);
+  if (isNaN(d.getTime())) throw new Error(`Invalid date for '${paramName}': "${s}"`);
+  return d;
+}
+
 export async function listRecentIntel(params: {
   since?: string;
   until?: string;
@@ -9,8 +15,8 @@ export async function listRecentIntel(params: {
   page_type?: string;
   limit?: number;
 }) {
-  const since = params.since ? new Date(params.since) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-  const until = params.until ? new Date(params.until) : new Date();
+  const since = params.since ? parseDateArg(params.since, "since") : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const until = params.until ? parseDateArg(params.until, "until") : new Date();
   const limit = Math.min(params.limit ?? 50, MAX_LIMIT);
 
   const competitorFilter = params.competitor

--- a/mcp/src/tools/list-recent-intel.ts
+++ b/mcp/src/tools/list-recent-intel.ts
@@ -1,0 +1,51 @@
+import { prisma } from "../db.js";
+
+const MAX_LIMIT = 200;
+
+export async function listRecentIntel(params: {
+  since?: string;
+  until?: string;
+  competitor?: string;
+  page_type?: string;
+  limit?: number;
+}) {
+  const since = params.since ? new Date(params.since) : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const until = params.until ? new Date(params.until) : new Date();
+  const limit = Math.min(params.limit ?? 50, MAX_LIMIT);
+
+  const competitorFilter = params.competitor
+    ? { page: { competitor: { slug: params.competitor } } }
+    : { page: { competitor: { isSelf: false } } };
+
+  const scans = await prisma.scan.findMany({
+    where: {
+      hasChanges: true,
+      scannedAt: { gte: since, lte: until },
+      ...(params.page_type ? { page: { ...competitorFilter.page, type: params.page_type } } : competitorFilter)
+    },
+    include: {
+      page: {
+        include: { competitor: { select: { name: true, slug: true } } }
+      }
+    },
+    orderBy: { scannedAt: "desc" },
+    take: limit + 1
+  });
+
+  const hasMore = scans.length > limit;
+  const entries = scans.slice(0, limit);
+
+  return {
+    entries: entries.map((s) => ({
+      id: s.id,
+      competitor: s.page.competitor.name,
+      competitor_slug: s.page.competitor.slug,
+      page_type: s.page.type,
+      detected_at: s.scannedAt.toISOString(),
+      summary: s.diffSummary ?? null,
+      source_url: s.page.url
+    })),
+    total: entries.length,
+    has_more: hasMore
+  };
+}

--- a/mcp/src/tools/search-intel.ts
+++ b/mcp/src/tools/search-intel.ts
@@ -1,0 +1,44 @@
+import { prisma } from "../db.js";
+
+const MAX_LIMIT = 100;
+
+export async function searchIntel(query: string, since?: string, limit = 25) {
+  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const safeLimit = Math.min(limit, MAX_LIMIT);
+
+  const scans = await prisma.scan.findMany({
+    where: {
+      hasChanges: true,
+      scannedAt: { gte: sinceDate },
+      page: { competitor: { isSelf: false } },
+      OR: [
+        { diffSummary: { contains: query, mode: "insensitive" } },
+        { summary: { contains: query, mode: "insensitive" } }
+      ]
+    },
+    include: {
+      page: {
+        include: { competitor: { select: { name: true, slug: true } } }
+      }
+    },
+    orderBy: { scannedAt: "desc" },
+    take: safeLimit + 1
+  });
+
+  const hasMore = scans.length > safeLimit;
+  const entries = scans.slice(0, safeLimit);
+
+  return {
+    entries: entries.map((s) => ({
+      id: s.id,
+      competitor: s.page.competitor.name,
+      competitor_slug: s.page.competitor.slug,
+      page_type: s.page.type,
+      detected_at: s.scannedAt.toISOString(),
+      summary: s.diffSummary ?? null,
+      source_url: s.page.url
+    })),
+    total: entries.length,
+    has_more: hasMore
+  };
+}

--- a/mcp/src/tools/search-intel.ts
+++ b/mcp/src/tools/search-intel.ts
@@ -2,8 +2,14 @@ import { prisma } from "../db.js";
 
 const MAX_LIMIT = 100;
 
+function parseDateArg(s: string, paramName: string): Date {
+  const d = new Date(s);
+  if (isNaN(d.getTime())) throw new Error(`Invalid date for '${paramName}': "${s}"`);
+  return d;
+}
+
 export async function searchIntel(query: string, since?: string, limit = 25) {
-  const sinceDate = since ? new Date(since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const sinceDate = since ? parseDateArg(since, "since") : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const safeLimit = Math.min(limit, MAX_LIMIT);
 
   const scans = await prisma.scan.findMany({

--- a/mcp/src/transports/http.ts
+++ b/mcp/src/transports/http.ts
@@ -1,0 +1,29 @@
+import express from "express";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createServer } from "../server.js";
+
+export async function startHttp(port: number, token: string): Promise<void> {
+  const app = express();
+  app.use(express.json());
+
+  app.use((req, res, next) => {
+    const auth = req.headers.authorization;
+    if (!auth || auth !== `Bearer ${token}`) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    next();
+  });
+
+  const server = createServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  await server.connect(transport);
+
+  app.all("/mcp", async (req, res) => {
+    await transport.handleRequest(req, res, req.body);
+  });
+
+  app.listen(port, () => {
+    console.error(`Rival MCP server listening on port ${port}`);
+  });
+}

--- a/mcp/src/transports/stdio.ts
+++ b/mcp/src/transports/stdio.ts
@@ -1,0 +1,8 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createServer } from "../server.js";
+
+export async function startStdio(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["../*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Closes #72

## Summary

Builds the Rival MCP server in `mcp/` — a standalone TypeScript package that exposes all competitor intelligence as read-only MCP tools. Once registered in Claude Desktop or Claude Code, Claude can query pricing tiers, hiring signals, intelligence briefs, deep dive reports, and the full intel feed directly from the database.

## What's in the box

**8 tools:**
- `list_competitors` — threat matrix sorted high→low, with health scores
- `get_competitor` — full snapshot including manual data (funding, G2, traffic)
- `get_competitor_data` — current structured extracted data per page type (pricing tiers, job listings, tech stack from JDs, GitHub stats, blog topics, review themes)
- `get_intelligence_brief` — AI brief with all 7 axis scores
- `get_deep_dives` — agentic research reports with citations
- `list_recent_intel` — intel feed, filterable by time/competitor/page type
- `get_competitor_diff` — before/after content for specific changes, truncated at 8000 chars
- `search_intel` — full-text search across the feed

**Transports:**
- stdio (default, for Claude Desktop / Claude Code local use)
- HTTP with bearer auth (for remote/shared use)

**66 unit tests across 8 files.** Clean build and typecheck.

## Files changed

- `mcp/` — new standalone sub-package
- `vitest.config.ts` — exclude `.worktrees/` and `.netlify/` from test glob (pre-existing issue fixed as part of this branch)
- `app/api/__tests__/demo.route.test.ts` — add missing `inferPageTypeFromUrl` to scanner mock (pre-existing test gap fixed)

## Setup after merge

```bash
cd mcp && npm install && npm run build
```

Then add to `claude_desktop_config.json` — see `mcp/README.md`.

## Approval Gates (per issue #72)

- [ ] Gate 1: Run all 8 tools manually against live DB, paste sample outputs in PR comment
- [ ] Gate 2: Register in Claude Desktop, verify all 8 tools appear and return real data