### PR TITLE
feat(quiver): nightly competitor push to Quiver research layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ DEMO_RATE_LIMIT=3
 CRON_SECRET=
 INTERNAL_API_KEY=
 MANUAL_STALE_DAYS=30
+
+# Quiver integration (optional) — push nightly competitor reports to Quiver research layer
+QUIVER_MCP_URL=
+QUIVER_MCP_SECRET=

--- a/app/api/quiver-sync/route.ts
+++ b/app/api/quiver-sync/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { hasValidInternalApiKey } from "@/app/api/_lib/auth";
+import { prisma } from "@/lib/db/client";
+import { pushCompetitorToQuiver } from "@/lib/quiver";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/quiver-sync
+ *
+ * Pushes all tracked competitors to Quiver's research layer using existing
+ * scan data — no re-scanning. Useful for a manual first-run or re-sync.
+ *
+ * Auth: INTERNAL_API_KEY via x-internal-api-key header or Bearer token.
+ *
+ * curl example:
+ *   curl -X POST https://your-rival.com/api/quiver-sync \
+ *     -H "x-internal-api-key: <INTERNAL_API_KEY>"
+ */
+export async function POST(request: NextRequest) {
+  if (!hasValidInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const competitors = await prisma.competitor.findMany({
+    where: { isSelf: false },
+    select: { id: true, name: true, baseUrl: true }
+  });
+
+  const results: Array<{ name: string; status: "pushed" | "skipped" }> = [];
+
+  for (const c of competitors) {
+    await pushCompetitorToQuiver(c.id, c.name, c.baseUrl);
+    results.push({ name: c.name, status: "pushed" });
+  }
+
+  return NextResponse.json({ pushed: results.length, competitors: results });
+}

--- a/lib/__tests__/quiver.test.ts
+++ b/lib/__tests__/quiver.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  competitorFindUniqueMock,
+  competitorPageFindManyMock,
+  scanFindManyMock,
+  fetchMock
+} = vi.hoisted(() => ({
+  competitorFindUniqueMock: vi.fn(),
+  competitorPageFindManyMock: vi.fn(),
+  scanFindManyMock: vi.fn(),
+  fetchMock: vi.fn()
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: {
+    competitor: { findUnique: competitorFindUniqueMock },
+    competitorPage: { findMany: competitorPageFindManyMock },
+    scan: { findMany: scanFindManyMock }
+  }
+}));
+
+vi.stubGlobal("fetch", fetchMock);
+
+const COMPETITOR_ID = "comp-1";
+const NAME = "Acme";
+const BASE_URL = "https://acme.com";
+
+function makeOkResponse(body: unknown) {
+  return { ok: true, json: async () => body } as Response;
+}
+
+describe("pushCompetitorToQuiver", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.QUIVER_MCP_URL = "https://quiver.example.com/api/mcp";
+    process.env.QUIVER_MCP_SECRET = "test-secret";
+
+    competitorFindUniqueMock.mockResolvedValue({
+      threatLevel: "High",
+      intelligenceBrief: {
+        threat_reasoning: "Direct competitor",
+        positioning_opportunity: "Fill the gap",
+        content_opportunity: "Own the docs space",
+        product_opportunity: "Better SDK",
+        watch_list: ["pricing change signal"]
+      },
+      manualData: { total_funding: "$20M", employee_count: 120 }
+    });
+    competitorPageFindManyMock.mockResolvedValue([]);
+    scanFindManyMock.mockResolvedValue([]);
+    fetchMock.mockResolvedValue(makeOkResponse({ result: { entry_id: "e1", processing: true } }));
+  });
+
+  it("does nothing when QUIVER_MCP_URL is not set", async () => {
+    delete process.env.QUIVER_MCP_URL;
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when QUIVER_MCP_SECRET is not set", async () => {
+    delete process.env.QUIVER_MCP_SECRET;
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs to QUIVER_MCP_URL with bearer auth", async () => {
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://quiver.example.com/api/mcp");
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer test-secret");
+  });
+
+  it("calls save_research_entry via MCP tools/call", async () => {
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.method).toBe("tools/call");
+    expect(body.params.name).toBe("save_research_entry");
+    expect(body.params.arguments.source_type).toBe("other");
+    expect(body.params.arguments.contact_company).toBe(NAME);
+    expect(body.params.arguments.title).toMatch(/^Rival: Acme — \d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("includes intelligence brief content in raw_notes", async () => {
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    const rawNotes: string = body.params.arguments.raw_notes;
+    expect(rawNotes).toContain("Direct competitor");
+    expect(rawNotes).toContain("Fill the gap");
+    expect(rawNotes).toContain("pricing change signal");
+  });
+
+  it("includes recent changes in raw_notes", async () => {
+    scanFindManyMock.mockResolvedValue([
+      {
+        diffSummary: "Added enterprise tier",
+        page: { label: "Pricing", type: "pricing" }
+      }
+    ]);
+
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.params.arguments.raw_notes).toContain("Added enterprise tier");
+  });
+
+  it("includes pricing data when a pricing scan exists", async () => {
+    competitorPageFindManyMock.mockResolvedValue([
+      {
+        type: "pricing",
+        scans: [{
+          rawResult: {
+            pricing_transparent: false,
+            has_free_tier: false,
+            tiers: [{ name: "Pro", price: "$99/mo", is_self_serve: true }]
+          }
+        }]
+      }
+    ]);
+
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.params.arguments.raw_notes).toContain("Pro");
+    expect(body.params.arguments.raw_notes).toContain("$99/mo");
+  });
+
+  it("does not throw when fetch fails — errors are swallowed", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Network error"));
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await expect(pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL)).resolves.toBeUndefined();
+  });
+
+  it("does not throw when Quiver returns a non-OK response", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401 } as Response);
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await expect(pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL)).resolves.toBeUndefined();
+  });
+
+  it("does not throw when Quiver returns a JSON-RPC error", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeOkResponse({ error: { code: -32000, message: "Something went wrong" } })
+    );
+    const { pushCompetitorToQuiver } = await import("@/lib/quiver");
+    await expect(pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL)).resolves.toBeUndefined();
+  });
+});

--- a/lib/quiver.ts
+++ b/lib/quiver.ts
@@ -1,0 +1,229 @@
+/**
+ * Quiver integration — nightly competitor push.
+ *
+ * After each scan cycle completes, pushes a structured competitive intelligence
+ * report to Quiver via its MCP HTTP endpoint (POST /api/mcp, bearer auth).
+ * Quiver AI processes it automatically: extracts quotes, themes, and sentiment.
+ *
+ * Config:
+ *   QUIVER_MCP_URL    — e.g. https://quiver.yourhost.com/api/mcp
+ *   QUIVER_MCP_SECRET — bearer token (Quiver's MCP_AUTH_SECRET)
+ *
+ * Failure policy: errors are logged but never thrown. A failed push must not
+ * block or fail the scan cycle that triggered it.
+ */
+
+import { prisma } from "@/lib/db/client";
+
+function isConfigured(): boolean {
+  return Boolean(process.env.QUIVER_MCP_URL && process.env.QUIVER_MCP_SECRET);
+}
+
+function asObj(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return null;
+}
+
+async function buildReport(competitorId: string, name: string, baseUrl: string): Promise<string> {
+  const [competitor, pages, recentChanges] = await Promise.all([
+    prisma.competitor.findUnique({
+      where: { id: competitorId },
+      select: { threatLevel: true, intelligenceBrief: true, manualData: true }
+    }),
+    prisma.competitorPage.findMany({
+      where: { competitorId },
+      include: {
+        scans: { orderBy: { scannedAt: "desc" }, take: 1 }
+      }
+    }),
+    prisma.scan.findMany({
+      where: {
+        hasChanges: true,
+        scannedAt: { gte: new Date(Date.now() - 25 * 60 * 60 * 1000) }, // last 25h covers nightly runs
+        page: { competitorId }
+      },
+      include: { page: { select: { label: true, type: true } } },
+      orderBy: { scannedAt: "desc" }
+    })
+  ]);
+
+  const brief = asObj(competitor?.intelligenceBrief);
+  const manual = asObj(competitor?.manualData);
+  const lines: string[] = [];
+
+  // ── Header ──────────────────────────────────────────────────────────────
+  lines.push(`# Competitive Intelligence: ${name}`);
+  lines.push(`URL: ${baseUrl}`);
+  lines.push(`Threat: ${competitor?.threatLevel ?? "unknown"}`);
+  if (manual?.total_funding) lines.push(`Funding: ${manual.total_funding}`);
+  if (manual?.employee_count ?? manual?.employees) lines.push(`Team: ${manual?.employee_count ?? manual?.employees}`);
+  if (manual?.monthly_traffic) lines.push(`Traffic: ${String(manual.monthly_traffic)}/mo`);
+  lines.push("");
+
+  // ── Intelligence brief ───────────────────────────────────────────────────
+  if (brief) {
+    lines.push("## Intelligence Brief");
+    if (brief.threat_reasoning) lines.push(`**Threat:** ${brief.threat_reasoning}`);
+    if (brief.positioning_opportunity) lines.push(`**Positioning opportunity:** ${brief.positioning_opportunity}`);
+    if (brief.content_opportunity) lines.push(`**Content opportunity:** ${brief.content_opportunity}`);
+    if (brief.product_opportunity) lines.push(`**Product opportunity:** ${brief.product_opportunity}`);
+    const watchList = Array.isArray(brief.watch_list)
+      ? (brief.watch_list as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    if (watchList.length > 0) {
+      lines.push("**Watch list:**");
+      watchList.forEach((item) => lines.push(`- ${item}`));
+    }
+    lines.push("");
+  }
+
+  // ── Scan data by page type ───────────────────────────────────────────────
+  const scansByType = new Map<string, unknown>();
+  for (const page of pages) {
+    if (page.scans[0]?.rawResult && !scansByType.has(page.type)) {
+      scansByType.set(page.type, page.scans[0].rawResult);
+    }
+  }
+
+  // Homepage / positioning
+  const homepage = asObj(scansByType.get("homepage"));
+  if (homepage) {
+    lines.push("## Positioning");
+    if (homepage.primary_tagline) lines.push(`> "${homepage.primary_tagline}"`);
+    if (homepage.sub_tagline) lines.push(`> ${homepage.sub_tagline}`);
+    if (homepage.positioning_statement) lines.push(`**Positioning:** ${homepage.positioning_statement}`);
+    if (homepage.primary_cta_text) lines.push(`**CTA:** "${homepage.primary_cta_text}"`);
+    const diffs = Array.isArray(homepage.key_differentiators)
+      ? (homepage.key_differentiators as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    if (diffs.length > 0) lines.push(`**Differentiators:** ${diffs.join(" · ")}`);
+    lines.push("");
+  }
+
+  // Pricing
+  const pricing = asObj(scansByType.get("pricing"));
+  if (pricing) {
+    lines.push("## Pricing");
+    lines.push(
+      `Transparent: ${pricing.pricing_transparent ? "Yes" : "No"} | Free tier: ${pricing.has_free_tier ? "Yes" : "No"}${pricing.free_tier_limits ? ` (${pricing.free_tier_limits})` : ""}`
+    );
+    const tiers = Array.isArray(pricing.tiers) ? pricing.tiers : [];
+    if (tiers.length > 0) {
+      tiers.forEach((tier: unknown) => {
+        const t = asObj(tier);
+        if (t?.name) lines.push(`- ${t.name}: ${t.price ?? "—"}${t.per_unit ? ` + ${t.per_unit}` : ""}${t.is_self_serve === false ? " (sales required)" : ""}`);
+      });
+    }
+    lines.push("");
+  }
+
+  // Careers / tech stack
+  const careers = asObj(scansByType.get("careers"));
+  if (careers) {
+    lines.push("## Hiring Signals");
+    if (careers.total_count != null) lines.push(`Open roles: ${careers.total_count} | Trend: ${careers.hiring_trend ?? "unknown"}`);
+    if (careers.devrel_roles_open) lines.push("DevRel roles open — community investment signal");
+    if (careers.leadership_roles_open) lines.push("Leadership roles open — org change signal");
+    const stack = Array.isArray(careers.aggregate_tech_stack)
+      ? (careers.aggregate_tech_stack as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    if (stack.length > 0) lines.push(`Tech stack (from JDs): ${stack.join(", ")}`);
+    lines.push("");
+  }
+
+  // Reviews
+  const reviews = asObj(scansByType.get("reviews"));
+  if (reviews) {
+    lines.push("## Customer Sentiment");
+    if (reviews.platform && reviews.overall_rating != null) {
+      lines.push(`${reviews.platform}: ${reviews.overall_rating}/5${reviews.review_count ? ` (${reviews.review_count} reviews)` : ""}`);
+    }
+    const praise = Array.isArray(reviews.top_praise_themes)
+      ? (reviews.top_praise_themes as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    const complaints = Array.isArray(reviews.top_complaint_themes)
+      ? (reviews.top_complaint_themes as unknown[]).filter((x): x is string => typeof x === "string")
+      : [];
+    if (praise.length > 0) lines.push(`Praise: ${praise.join(", ")}`);
+    if (complaints.length > 0) lines.push(`Complaints: ${complaints.join(", ")}`);
+    lines.push("");
+  }
+
+  // GitHub
+  const github = asObj(scansByType.get("github"));
+  if (github) {
+    lines.push("## GitHub");
+    const parts: string[] = [];
+    if (github.stars != null) parts.push(`${Number(github.stars).toLocaleString()} stars`);
+    if (github.forks != null) parts.push(`${github.forks} forks`);
+    if (github.last_commit_date) parts.push(`last commit ${github.last_commit_date}`);
+    if (parts.length > 0) lines.push(parts.join(" | "));
+    const topics = Array.isArray(github.topics) ? (github.topics as unknown[]).filter((x): x is string => typeof x === "string") : [];
+    if (topics.length > 0) lines.push(`Topics: ${topics.join(", ")}`);
+    lines.push("");
+  }
+
+  // Recent changes
+  if (recentChanges.length > 0) {
+    lines.push("## Changes Detected This Cycle");
+    recentChanges.forEach((s) => {
+      lines.push(`- **${s.page.label}:** ${s.diffSummary ?? "Changed"}`);
+    });
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+export async function pushCompetitorToQuiver(
+  competitorId: string,
+  name: string,
+  baseUrl: string
+): Promise<void> {
+  if (!isConfigured()) return;
+
+  const url = process.env.QUIVER_MCP_URL!;
+  const secret = process.env.QUIVER_MCP_SECRET!;
+  const today = new Date().toISOString().slice(0, 10);
+
+  try {
+    const rawNotes = await buildReport(competitorId, name, baseUrl);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "save_research_entry",
+          arguments: {
+            title: `Rival: ${name} — ${today}`,
+            source_type: "other",
+            raw_notes: rawNotes,
+            contact_company: name,
+            research_date: today
+          }
+        }
+      })
+    });
+
+    if (!response.ok) {
+      console.error(`[quiver] push failed for ${name}: HTTP ${response.status}`);
+      return;
+    }
+
+    const body = (await response.json()) as { result?: unknown; error?: { message?: string } };
+    if (body.error) {
+      console.error(`[quiver] push error for ${name}:`, body.error.message);
+    } else {
+      console.log(`[quiver] pushed "${name}" to Quiver research`);
+    }
+  } catch (err) {
+    console.error(`[quiver] push threw for ${name}:`, err instanceof Error ? err.message : err);
+  }
+}

--- a/lib/run-scans.ts
+++ b/lib/run-scans.ts
@@ -1,5 +1,6 @@
 import { generateCompetitorBrief, generateSelfBrief } from "./brief";
 import { prisma } from "./db/client";
+import { pushCompetitorToQuiver } from "./quiver";
 import { scanPage } from "./scanner";
 
 const DEFAULT_CONCURRENCY = 3;
@@ -7,6 +8,8 @@ const STALE_LOCK_AGE_MS = 60 * 60 * 1000; // 1 hour
 
 type CompetitorWithPages = {
   id: string;
+  name: string;
+  baseUrl: string;
   isSelf: boolean;
   pages: Array<{
     id: string;
@@ -57,6 +60,10 @@ async function processCompetitor(competitor: CompetitorWithPages, briefNocache: 
     item.briefGenerated = true;
   } catch (error) {
     item.errors.push(`brief: ${error instanceof Error ? error.message : "brief failed"}`);
+  }
+
+  if (!competitor.isSelf) {
+    await pushCompetitorToQuiver(competitor.id, competitor.name, competitor.baseUrl);
   }
 
   return item;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     }
   },
   test: {
-    exclude: ["node_modules/**", ".worktrees/**", ".netlify/**"],
+    exclude: ["node_modules/**", ".worktrees/**", ".netlify/**", "mcp/node_modules/**"],
     environment: "node",
     clearMocks: true,
     restoreMocks: true,


### PR DESCRIPTION
After each nightly scan cycle, Rival pushes a structured competitive intelligence report for each competitor to Quiver's research layer via the Quiver MCP HTTP endpoint.

## What gets pushed

One research entry per competitor, created by `save_research_entry` with:
- Intelligence brief (positioning/content/product opportunities, watch list)
- Pricing tiers and transparency signal
- Hiring signals and tech stack fingerprint from JDs
- Customer sentiment (G2/Capterra themes if scanned)
- GitHub stats
- Recent changes detected in this scan cycle

AI processing in Quiver runs automatically — summary, quotes, themes, and sentiment are extracted and flow into session context.

## Config (opt-in)

Two new env vars — leave blank to disable:
```
QUIVER_MCP_URL=https://your-quiver-instance.com/api/mcp
QUIVER_MCP_SECRET=your-mcp-auth-secret
```

## Failure policy

Push errors are logged but never thrown. A failed Quiver push cannot block or fail the scan cycle.

## Files
- `lib/quiver.ts` — new module: report builder + MCP push
- `lib/run-scans.ts` — calls `pushCompetitorToQuiver` after each non-self competitor completes
- `lib/__tests__/quiver.test.ts` — 10 tests
- `vitest.config.ts` — exclude `mcp/node_modules/**` from test glob (pre-existing gap)