### PR TITLE
fix(quiver): add Accept header + parse SSE response format

### DIFF
--- a/lib/__tests__/quiver.test.ts
+++ b/lib/__tests__/quiver.test.ts
@@ -27,7 +27,8 @@ const NAME = "Acme";
 const BASE_URL = "https://acme.com";
 
 function makeOkResponse(body: unknown) {
-  return { ok: true, json: async () => body } as Response;
+  const sse = `event: message\ndata: ${JSON.stringify(body)}\n\n`;
+  return { ok: true, text: async () => sse } as unknown as Response;
 }
 
 describe("pushCompetitorToQuiver", () => {
@@ -144,7 +145,7 @@ describe("pushCompetitorToQuiver", () => {
   });
 
   it("does not throw when Quiver returns a non-OK response", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: false, status: 401 } as Response);
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 401, text: async () => "" } as unknown as Response);
     const { pushCompetitorToQuiver } = await import("@/lib/quiver");
     await expect(pushCompetitorToQuiver(COMPETITOR_ID, NAME, BASE_URL)).resolves.toBeUndefined();
   });

--- a/lib/quiver.ts
+++ b/lib/quiver.ts
@@ -193,6 +193,7 @@ export async function pushCompetitorToQuiver(
       method: "POST",
       headers: {
         "content-type": "application/json",
+        "accept": "application/json, text/event-stream",
         authorization: `Bearer ${secret}`
       },
       body: JSON.stringify({
@@ -217,7 +218,10 @@ export async function pushCompetitorToQuiver(
       return;
     }
 
-    const body = (await response.json()) as { result?: unknown; error?: { message?: string } };
+    // Quiver's MCP endpoint returns SSE format: "event: message\ndata: {...}\n\n"
+    const text = await response.text();
+    const dataLine = text.split("\n").find((l) => l.startsWith("data:"));
+    const body = dataLine ? (JSON.parse(dataLine.slice(5).trim()) as { result?: unknown; error?: { message?: string } }) : {};
     if (body.error) {
       console.error(`[quiver] push error for ${name}:`, body.error.message);
     } else {


### PR DESCRIPTION
Quiver's MCP endpoint requires `Accept: application/json, text/event-stream` and returns SSE format. Rival was sending plain JSON Accept and calling `response.json()` — both wrong. Fixes silent push failure.