### PR TITLE
fix(quiver): set contact_segment to Competitor on pushed entries

### DIFF
--- a/lib/quiver.ts
+++ b/lib/quiver.ts
@@ -207,6 +207,7 @@ export async function pushCompetitorToQuiver(
             source_type: "other",
             raw_notes: rawNotes,
             contact_company: name,
+            contact_segment: "Competitor",
             research_date: today
           }
         }


### PR DESCRIPTION
Sets contact_segment: 'Competitor' on all entries pushed from Rival so they're properly labeled and filterable in Quiver.